### PR TITLE
Object tests

### DIFF
--- a/ecmascript.py
+++ b/ecmascript.py
@@ -250,11 +250,16 @@ class JSObject:
 
     # 9.1.1 [[GetPrototypeOf]] ( )
     def GetPrototypeOf(self):
+        """Determine the object that provides inherited properties for this object. A null value indicates that there are no
+           inherited properties."""
         # 1. Return O.[[Prototype]].
         return NormalCompletion(self.Prototype)
 
     # 9.1.2 [[SetPrototypeOf]] ( V )
     def SetPrototypeOf(self, value):
+        """Associate this object with another object that provides inherited properties. Passing null indicates that there are
+           no inherited properties. Returns true indicating that the operation was completed successfully or false indicating
+           that the operation was not successful."""
         # When the abstract operation OrdinarySetPrototypeOf is called with Object O and value V, the following steps
         # are taken:
         # 1. Assert: Either Type(V) is Object or Type(V) is Null.
@@ -303,11 +308,14 @@ class JSObject:
 
     # 9.1.3 [[IsExtensible]] ( )
     def IsExtensible(self):
+        """Determine whether it is permitted to add additional properties to this object."""
         # 1. Return O.[[Extensible]].
         return NormalCompletion(self.Extensible)
 
     # 9.1.4 [[PreventExtensions]] ( )
     def PreventExtensions(self):
+        """Control whether new properties may be added to this object. Returns true if the operation was successful or false if
+           the operation was unsuccessful."""
         # 1. Set O.[[Extensible]] to false.
         self.Extensible = False
         # 2. Return true.
@@ -315,6 +323,8 @@ class JSObject:
 
     # 9.1.5 [[GetOwnProperty]] ( P )
     def GetOwnProperty(self, propkey):
+        """Return a Property Descriptor for the own property of this object whose key is propertyKey, or undefined if no such
+           property exists."""
         # 1. Assert: IsPropertyKey(P) is true.
         assert IsPropertyKey(propkey)
         # 2. If O does not have an own property with key P, return undefined.
@@ -345,6 +355,9 @@ class JSObject:
 
     # 9.1.6 [[DefineOwnProperty]] ( P, Desc )
     def DefineOwnProperty(self, propkey, desc):
+        """Create or alter the own property, whose key is propertyKey, to have the state described by PropertyDescriptor.
+           Return true if that property was successfully created/updated or false if the property could not be created or
+           updated."""
         # 1. Let current be ? O.[[GetOwnProperty]](P).
         current, ok = ec(self.GetOwnProperty(propkey))
         if not ok:
@@ -356,6 +369,8 @@ class JSObject:
 
     # 9.1.7 [[HasProperty]] ( P )
     def HasProperty(self, propkey):
+        """Return a Boolean value indicating whether this object already has either an own or inherited property whose key is
+           propertyKey."""
         # 1. Assert: IsPropertyKey(P) is true.
         assert IsPropertyKey(propkey)
         # 2. Let hasOwn be ? O.[[GetOwnProperty]](P).
@@ -378,6 +393,8 @@ class JSObject:
 
     # 9.1.8 [[Get]] ( P, Receiver )
     def Get(self, propkey, receiver):
+        """Return the value of the property whose key is propertyKey from this object. If any ECMAScript code must be executed
+           to retrieve the property value, Receiver is used as the this value when evaluating the code."""
         # When the abstract operation OrdinaryGet is called with Object O, property key P, and ECMAScript language
         # value Receiver, the following steps are taken:
         #
@@ -413,6 +430,9 @@ class JSObject:
 
     # 9.1.9 [[Set]] ( P, V, Receiver )
     def Set(self, propkey, value, receiver):
+        """Set the value of the property whose key is propertyKey to value. If any ECMAScript code must be executed to set the
+           property value, Receiver is used as the this value when evaluating the code. Returns true if the property value was
+           set or false if it could not be set."""
         # When the [[Set]] internal method of O is called with property key P, value V, and ECMAScript language value
         # Receiver, the following steps are taken:
         #
@@ -421,6 +441,8 @@ class JSObject:
 
     # 9.1.10 [[Delete]] ( P )
     def Delete(self, propkey):
+        """Remove the own property whose key is propertyKey from this object. Return false if the property was not deleted and
+           is still present. Return true if the property was deleted or is not present."""
         # When the [[Delete]] internal method of O is called with property key P, the following steps are taken:
         #
         # 1. Return ? OrdinaryDelete(O, P).
@@ -428,6 +450,7 @@ class JSObject:
 
     # 9.1.11 [[OwnPropertyKeys]] ( )
     def OwnPropertyKeys(self):
+        """Return a List whose elements are all of the own property keys for the object."""
         # When the [[OwnPropertyKeys]] internal method of O is called, the following steps are taken:
         #
         # 1. Return ! OrdinaryOwnPropertyKeys(O).
@@ -545,7 +568,8 @@ def ValidateAndApplyPropertyDescriptor(obj, propkey, extensible, desc, current):
     if obj is not None:
         # a. For each field of Desc that is present, set the corresponding attribute of the property named P of object
         #    O to the value of the field.
-        for fieldname in (f for f in ['value', 'writable', 'Get', 'Set', 'configurable', 'enumerable'] if hasattr(desc, f)):
+        for fieldname in (f for f in ['value', 'writable', 'Get', 'Set', 'configurable', 'enumerable']
+                          if hasattr(desc, f)):
             setattr(obj.properties[propkey], fieldname, getattr(desc, fieldname))
     # 10. Return true.
     return NormalCompletion(True)
@@ -912,7 +936,7 @@ def UpdateEmpty(cr, value):
 def ec(val):
     """ErrorCheck:
        Check val for an abrupt completion, returning "not ok" if that's the case. Else unwrap the Completion and return
-       the actual value. Just response with the value itself, if this isn't a completion record."""
+       the actual value. Just respond with the value itself, if this isn't a completion record."""
     if isinstance(val, Completion):
         if val.ctype != CompletionType.NORMAL:
             return (val, False)
@@ -1364,10 +1388,9 @@ def CompletePropertyDescriptor(desc):
 
 # 7 Abstract Operations
 #
-# These operations are not a part of the ECMAScript language; they are defined here to solely to aid the specification of
-# the semantics of the ECMAScript language. Other, more specialized abstract operations are defined throughout this
+# These operations are not a part of the ECMAScript language; they are defined here to solely to aid the specification
+# of the semantics of the ECMAScript language. Other, more specialized abstract operations are defined throughout this
 # specification.
-
 
 # 7.1 Type Conversion
 #
@@ -2100,7 +2123,7 @@ def GetFunctionRealm(obj):
         # c. Return ? GetFunctionRealm(proxyTarget).
         return GetFunctionRealm(proxy_target)
     # 5. Return the current Realm Record.
-    return None ## @@@FIXME@@@
+    return surrounding_agent.running_ec.realm
     # NOTE
     # Step 5 will only be reached if obj is a non-standard function exotic object that does not have a [[Realm]]
     # internal slot.
@@ -3337,7 +3360,7 @@ def SetDefaultGlobalBindings(realm_rec):
     # 2. For each property of the Global Object specified in clause 18, do
     global_values = [
         ('Infinity', math.inf),
-        ('Nan', math.nan),
+        ('NaN', math.nan),
         ('undefined', None)
     ]
     global_intrinsics = [
@@ -3368,7 +3391,7 @@ def SetDefaultGlobalBindings(realm_rec):
         'URIError', 'WeapMap', 'WeakSet', 'Atomics', 'JSON', 'Math', 'Reflect']
     # @@@ Note: The "if" clause, below, should not be there. It's just to allow this fcn to work even if I haven't
     # implemented everything yet.
-    for name, value in chain(global_values, ((name, realm_rec.intrinsics['%'+name+'%']) for name in global_intrinsics if hasattr(realm_rec.intrinsics, '%'+name+'%'))):
+    for name, value in chain(global_values, ((name, realm_rec.intrinsics['%'+name+'%']) for name in global_intrinsics if '%'+name+"%" in realm_rec.intrinsics)):
         # a. Let name be the String value of the property name.x
         # b. Let desc be the fully populated data property descriptor for the property containing the specified
         #    attributes for the property. For properties listed in 18.2, 18.3, or 18.4 the value of the [[Value]]
@@ -4707,6 +4730,22 @@ def ScriptEvaluationJob(source_text, host_defined):
 #     * creates a new ordinary object when called as a constructor.
 #     * performs a type conversion when called as a function rather than as a constructor.
 #     * is designed to be subclassable. It may be used as the value of an extends clause of a class definition.
+def BindBuiltinFunctions(realm, obj, details):
+    for key, fcn, length in details:
+        func_obj, ok = ec(CreateBuiltinFunction(fcn, [], realm))
+        if not ok:
+            return func_obj
+        success, ok = ec(DefinePropertyOrThrow(func_obj, 'length', PropertyDescriptor(value=length, writable=False, enumerable=False, configurable=True)))
+        if not ok:
+            return success
+        success, ok = ec(DefinePropertyOrThrow(func_obj, 'name', PropertyDescriptor(value=key, writable=False, enumerable=False, configurable=True)))
+        if not ok:
+            return success
+        success, ok = ec(CreateMethodPropertyOrThrow(obj, key, func_obj))
+        if not ok:
+            return success
+    return NormalCompletion(None)
+
 def CreateObjectConstructor(realm):
     intrinsics = realm.intrinsics
     obj = ObjectCreate(intrinsics['%FunctionPrototype%'])
@@ -4717,7 +4756,7 @@ def CreateObjectConstructor(realm):
     cr, ok = ec(DefinePropertyOrThrow(obj, 'prototype', PropertyDescriptor(value=intrinsics['%ObjectPrototype%'], writable=False, enumerable=False, configurable=False)))
     if not ok:
         return cr
-    for key, fcn, length in [
+    cr, ok = ec(BindBuiltinFunctions(realm, obj, [
         ('assign', ObjectMethod_assign, 2),
         ('create', ObjectMethod_create, 2),
         ('defineProperties', ObjectMethod_defineProperties, 2),
@@ -4737,20 +4776,9 @@ def CreateObjectConstructor(realm):
         ('preventExtensions', ObjectMethod_preventExtensions, 1),
         ('seal', ObjectMethod_seal, 1),
         ('setPrototypeOf', ObjectMethod_setPrototypeOf, 2),
-        ('values', ObjectMethod_values, 1)
-    ]:
-        func_obj, ok = ec(CreateBuiltinFunction(fcn, [], realm))
-        if not ok:
-            return func_obj
-        success, ok = ec(DefinePropertyOrThrow(func_obj, 'length', PropertyDescriptor(value=length, writable=False, enumerable=False, configurable=True)))
-        if not ok:
-            return success
-        success, ok = ec(DefinePropertyOrThrow(func_obj, 'name', PropertyDescriptor(value=key, writable=False, enumerable=False, configurable=True)))
-        if not ok:
-            return success
-        success, ok = ec(CreateMethodPropertyOrThrow(obj, key, func_obj))
-        if not ok:
-            return success
+        ('values', ObjectMethod_values, 1)]))
+    if not ok:
+        return cr
     return obj
 
 # 19.1.2.1 Object.assign ( target, ...sources )
@@ -5157,26 +5185,16 @@ def AddObjectPrototypeProps(realm_rec):
     cr, ok = ec(DefinePropertyOrThrow(obj, 'constructor', PropertyDescriptor(value=intrinsics['%Object%'], writable=False, enumerable=False, configurable=False)))
     if not ok:
         return cr
-    for key, fcn, length in [
+    cr, ok = ec(BindBuiltinFunctions(realm_rec, obj, [
         ('hasOwnProperty', ObjectPrototype_hasOwnProperty, 1),
         ('isPrototypeOf', ObjectPrototype_isPrototypeOf, 1),
         ('propertyIsEnumerable', ObjectPrototype_propertyIsEnumerable, 1),
         ('toLocaleString', ObjectPrototype_toLocaleString, 0),
         ('toString', ObjectPrototype_toString, 0),
         ('valueOf', ObjectPrototype_valueOf, 0)
-    ]:
-        func_obj, ok = ec(CreateBuiltinFunction(fcn, [], realm_rec))
-        if not ok:
-            return func_obj
-        success, ok = ec(DefinePropertyOrThrow(func_obj, 'length', PropertyDescriptor(value=length, writable=False, enumerable=False, configurable=True)))
-        if not ok:
-            return success
-        success, ok = ec(DefinePropertyOrThrow(func_obj, 'name', PropertyDescriptor(value=key, writable=False, enumerable=False, configurable=True)))
-        if not ok:
-            return success
-        success, ok = ec(CreateMethodPropertyOrThrow(obj, key, func_obj))
-        if not ok:
-            return success
+        ]))
+    if not ok:
+        return cr
     return NormalCompletion(None)
 
 # 19.1.3.2 Object.prototype.hasOwnProperty ( V )
@@ -5344,3 +5362,4 @@ def ObjectPrototype_valueOf(this_value):
 if __name__ == '__main__':
     InitializeHostDefinedRealm()
     realm = surrounding_agent.running_ec.realm
+    print('\n'.join('%s: %s' % (key, nc(ToString(nc(Get(realm.global_object, key))))) for key in nc(realm.global_object.OwnPropertyKeys())))

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -65,3 +65,443 @@ def test_object_SetPrototypeOf_method_05(object_chain):
 
     assert object_chain['ancestor'].SetPrototypeOf(object_chain['child']) == Completion(NORMAL, True, None)
     assert object_chain['ancestor'].GetPrototypeOf().value == object_chain['child']
+
+@pytest.mark.parametrize('input, expected', [(True, True), (False, False)])
+def test_object_IsExtensible_method(realm, input, expected):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    obj.Extensible = input
+
+    assert obj.IsExtensible() == Completion(NORMAL, expected, None)
+
+def test_object_PreventExtensions_method(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    assert obj.IsExtensible().value
+    assert obj.PreventExtensions() == Completion(NORMAL, True, None)
+    assert not obj.IsExtensible().value
+
+def test_object_GetOwnProperty_method_01(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    # If O doesn't have the property, returns undefined.
+    assert obj.GetOwnProperty('not_here') == Completion(NORMAL, None, None)
+
+def test_object_GetOwnProperty_method_02(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    desc = PropertyDescriptor(value=100, writable=True, enumerable=True, configurable=True)
+    DefinePropertyOrThrow(obj, 'testkey', desc)
+
+    cr = obj.GetOwnProperty('testkey')
+    assert isinstance(cr, Completion)
+    assert (cr.ctype, cr.target) == (NORMAL, None)
+    assert isinstance(cr.value, PropertyDescriptor)
+    assert cr.value.is_data_descriptor() and not cr.value.is_accessor_descriptor()
+    assert (cr.value.value, cr.value.writable, cr.value.enumerable, cr.value.configurable) == (100, True, True, True)
+
+def test_object_GetOwnProperty_method_03(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'], ['test_slot'])
+    def test_get(self):
+        return NormalCompletion(self.test_slot)
+    def test_set(self, val):
+        self.test_slot = val
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    desc = PropertyDescriptor(Get=get_func, Set=set_func, enumerable=False, configurable=True)
+    DefinePropertyOrThrow(obj, 'testkey', desc)
+
+    cr = obj.GetOwnProperty('testkey')
+    assert isinstance(cr, Completion)
+    assert (cr.ctype, cr.target) == (NORMAL, None)
+    assert isinstance(cr.value, PropertyDescriptor)
+    assert not cr.value.is_data_descriptor() and cr.value.is_accessor_descriptor()
+    assert (cr.value.Get, cr.value.Set, cr.value.enumerable, cr.value.configurable) == (get_func, set_func, False, True)
+
+def test_ValidateAndApplyPropertyDescriptor_01(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    # If current == None, and not extensible return False.
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', False, PropertyDescriptor(), None)
+    assert cr == Completion(NORMAL, False, None)
+
+def test_ValidateAndApplyPropertyDescriptor_02(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    # If current == None, and the descriptor is empty, we make a default property.
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(), None)
+    assert cr == Completion(NORMAL, True, None)
+    pdesc = obj.GetOwnProperty('testkey').value
+    assert pdesc.is_data_descriptor() and not pdesc.is_accessor_descriptor()
+    assert (pdesc.value, pdesc.writable, pdesc.enumerable, pdesc.configurable) == (None, False, False, False)
+
+def test_ValidateAndApplyPropertyDescriptor_03(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    # If current == None, and the descriptor is full, we make a copy.
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(value=102, writable=True, enumerable=True, configurable=True), None)
+    assert cr == Completion(NORMAL, True, None)
+    pdesc = obj.GetOwnProperty('testkey').value
+    assert pdesc.is_data_descriptor() and not pdesc.is_accessor_descriptor()
+    assert (pdesc.value, pdesc.writable, pdesc.enumerable, pdesc.configurable) == (102, True, True, True)
+
+def test_ValidateAndApplyPropertyDescriptor_04(realm):
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    # If current == None, and the descriptor is partial, the rest gets filled with defaults.
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(Get=None, enumerable=True), None)
+    assert cr == Completion(NORMAL, True, None)
+    pdesc = obj.GetOwnProperty('testkey').value
+    assert not pdesc.is_data_descriptor() and pdesc.is_accessor_descriptor()
+    assert (pdesc.Get, pdesc.Set, pdesc.enumerable, pdesc.configurable) == (None, None, True, False)
+
+def test_ValidateAndApplyPropertyDescriptor_05(realm):
+    # If current is None, obj is None, and extensible is True, it doesn't matter what the descriptor has. We just
+    # return True.
+    cr = ValidateAndApplyPropertyDescriptor(None, None, True, None, None)
+    assert cr == Completion(NORMAL, True, None)
+
+def test_ValidateAndApplyPropertyDescriptor_06(realm):
+    # Current has a value and the descriptor is empty: it's all good.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    CreateDataProperty(obj, 'testkey', 89)
+    current = obj.GetOwnProperty('testkey').value
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(), current)
+    assert cr == Completion(NORMAL, True, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_07(realm):
+    # If the current property is not configurable, we can't change it to *be* configurable.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(configurable=True), current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_08(realm):
+    # If the current property is not configurable, we can't change its enumerability
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(enumerable=False), current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_09(realm):
+    # If the configurable/enumerable flags are ok, but there's nothing else, just be true.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(enumerable=True), current)
+    assert cr == Completion(NORMAL, True, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_10(realm):
+    # If the current prop is not configurable, switching from data to accessor isn't allowed (or vice versa, for that
+    # matter).
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, PropertyDescriptor(Get=None, Set=None), current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_11(realm):
+    # Switch from a data descriptor to an accessor descriptor
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=True))
+    current = obj.GetOwnProperty('testkey').value
+
+    def test_get(self):
+        return NormalCompletion('nonsense')
+    def test_set(self, val):
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    desc = PropertyDescriptor(Get=get_func, Set=set_func, enumerable=False, configurable=True)
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, True, None)
+    after = obj.GetOwnProperty('testkey').value
+    assert after.is_accessor_descriptor() and not after.is_data_descriptor()
+    assert (after.Get, after.Set, after.enumerable, after.configurable) == (get_func, set_func, False, True)
+
+def test_ValidateAndApplyPropertyDescriptor_12(realm):
+    # Switch from an accessor descriptor to a data descriptor
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    def test_get(self):
+        return NormalCompletion('nonsense')
+    def test_set(self, val):
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(Get=get_func, Set=set_func, enumerable=True, configurable=True))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(value=33, writable=True, enumerable=False, configurable=True)
+
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, True, None)
+    after = obj.GetOwnProperty('testkey').value
+    assert not after.is_accessor_descriptor() and after.is_data_descriptor()
+    assert (after.value, after.writable, after.enumerable, after.configurable) == (33, True, False, True)
+
+def test_ValidateAndApplyPropertyDescriptor_13(realm):
+    # If the property is not configurable, changing from "not writable" to "writable" is not allowed.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=False, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(writable=True)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_14(realm):
+    # But: going from "writable" to "not writable" is just fine.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(writable=False)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, True, None)
+    # Only writable has changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, False, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_15(realm):
+    # If the property is not configurable, nor writable, then changing the value is not allowed.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=False, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(value=11)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_16(realm):
+    # If the property is not configurable, nor writable, setting the value but not changing it is fine.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=False, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(value=10)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, True, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.value, current.writable, current.enumerable, current.configurable) == \
+                (after.value, after.writable, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_17(realm):
+    # For Accessor descriptors, changing Get or Set is not allowed if the property is not configurable
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    def test_get(self):
+        return NormalCompletion('nonsense')
+    def test_set(self, val):
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(Get=get_func, Set=set_func, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(Get=None)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.Get, current.Set, current.enumerable, current.configurable) == \
+                (after.Get, after.Set, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_18(realm):
+    # For Accessor descriptors, changing Get or Set is not allowed if the property is not configurable
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    def test_get(self):
+        return NormalCompletion('nonsense')
+    def test_set(self, val):
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(Get=get_func, Set=set_func, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(Set=None)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    assert cr == Completion(NORMAL, False, None)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.Get, current.Set, current.enumerable, current.configurable) == \
+                (after.Get, after.Set, after.enumerable, after.configurable)
+
+def test_ValidateAndApplyPropertyDescriptor_19(realm):
+    # For non-configurable Accessor descriptors, setting Get or Set to their current values is fine.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    def test_get(self):
+        return NormalCompletion('nonsense')
+    def test_set(self, val):
+        return NormalCompletion(None)
+    get_func = CreateBuiltinFunction(test_get, [], realm)
+    set_func = CreateBuiltinFunction(test_set, [], realm)
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(Get=get_func, Set=set_func, enumerable=True, configurable=False))
+    current = obj.GetOwnProperty('testkey').value
+
+    desc = PropertyDescriptor(Get=get_func, Set=set_func)
+    cr = ValidateAndApplyPropertyDescriptor(obj, 'testkey', True, desc, current)
+    # Nothing should have been changed:
+    after = obj.GetOwnProperty('testkey').value
+    assert (current.Get, current.Set, current.enumerable, current.configurable) == \
+                (after.Get, after.Set, after.enumerable, after.configurable)
+
+# [[DefineOwnProperty]] on objects: if we assume ValidateAndApplyPropertyDescriptor works properly,
+# all we care about here:
+#   * Ensuring that we pass the Extensible property correctly;
+#   * Ensuring the arguments to our method (the key and the descriptor) get to where they need to go;
+#   * Ensuring the exception paths are exercised
+def test_object_DefineOwnProperty_method_01(realm):
+    # We can replace properties on extensible objects
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    DefinePropertyOrThrow(obj, 'testkey', PropertyDescriptor(value=10, writable=True, enumerable=True, configurable=True))
+
+    desc = PropertyDescriptor(value=15)
+    cr = obj.DefineOwnProperty('testkey', desc)
+    assert cr == Completion(NORMAL, True, None)
+    after = obj.GetOwnProperty('testkey').value
+    assert (after.value, after.writable, after.enumerable, after.configurable) == (15, True, True, True)
+
+def test_object_DefineOwnProperty_method_02(realm):
+    # We can add properties to extensible objects
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    desc = PropertyDescriptor(value=120)
+    cr = obj.DefineOwnProperty('testkey', desc)
+    assert cr == Completion(NORMAL, True, None)
+    after = obj.GetOwnProperty('testkey').value
+    assert (after.value, after.writable, after.enumerable, after.configurable) == (120, False, False, False)
+
+def test_object_DefineOwnProperty_method_03(realm):
+    # We cannot add new properties to non-extensible objects
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    obj.PreventExtensions()
+
+    desc = PropertyDescriptor(value=120)
+    cr = obj.DefineOwnProperty('testkey', desc)
+    assert cr == Completion(NORMAL, False, None)
+    assert not obj.HasProperty('testkey').value
+
+def test_object_DefineOwnProperty_method_04(realm):
+    # If an exception happens in [[GetOwnProperty]], it bubbles up. The default implementaion of that method can't actually
+    # fail, though, so we have to make one that throws deliberately.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    obj.GetOwnProperty = types.MethodType(lambda _a, _b: ThrowCompletion('Thrown from 04'), 'GetOwnProperty')
+
+    desc = PropertyDescriptor(value=120)
+    cr = obj.DefineOwnProperty('testkey', desc)
+    assert cr == Completion(THROW, 'Thrown from 04', None)
+
+def test_object_HasProperty_method_01(realm):
+    # Returns True when the key is an own property
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    CreateDataProperty(obj, 'testkey', 10)
+
+    cr = obj.HasProperty('testkey')
+    assert cr == Completion(NORMAL, True, None)
+
+def test_object_HasProperty_method_02(realm):
+    # Returns True when the key is on the prototype chain
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    cr = obj.HasProperty('toString')
+    assert cr == Completion(NORMAL, True, None)
+
+def test_object_HasProperty_method_03(realm):
+    # Returns False when the key is nowhere to be found
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+
+    cr = obj.HasProperty('toElephant')
+    assert cr == Completion(NORMAL, False, None)
+
+def test_object_HasProperty_method_04(realm):
+    # Exceptions from [[GetOwnProperty]] bubble up. (Step 2, in the algorithm.)
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    obj.GetOwnProperty = types.MethodType(lambda _a, _b: ThrowCompletion('Thrown from 04'), 'GetOwnProperty')
+
+    cr = obj.HasProperty('toElephant')
+    assert cr == Completion(THROW, 'Thrown from 04', None)
+
+def test_object_HasProperty_method_05(realm):
+    # Exceptions from [[GetPrototypeOf]] bubble up.
+    obj = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    obj.GetPrototypeOf = types.MethodType(lambda _: ThrowCompletion('Thrown from 05'), 'GetPrototypeOf')
+
+    cr = obj.HasProperty('toElephant')
+    assert cr == Completion(THROW, 'Thrown from 05', None)
+
+@pytest.fixture
+def get_tree(realm):
+    parent = ObjectCreate(realm.intrinsics['%ObjectPrototype%'])
+    child = ObjectCreate(parent)
+    CreateDataProperty(parent, 'onparent', 100)
+    CreateDataProperty(child, 'onchild', -100)
+    def special_get(self):
+        return NormalCompletion(self)
+    get_fcn = nc(CreateBuiltinFunction(special_get, [], realm=realm))
+    DefinePropertyOrThrow(child, 'accessor', PropertyDescriptor(Get=get_fcn, enumerable=True, configurable=True))
+    DefinePropertyOrThrow(child, 'dead', PropertyDescriptor(Get=None, enumerabl=True, configurable=True))
+    return child
+
+@pytest.mark.parametrize('input, expected', [
+    ('onchild', -100), # Getting a data property on self works.
+    ('onparent', 100), # Getting a data prop on parent works.
+    ('circus_performers', None), # A property that isn't there at all returns undefined
+    ('accessor', 345), # An accessor property works.
+    ('dead', None) # An empty Get function on the accessor prop means Undefined happens.
+    ])
+def test_object_Get_method(get_tree, input, expected):
+    val = get_tree.Get(input, 345)
+    assert val == Completion(NORMAL, expected, None)
+
+def test_object_Get_method_01(get_tree):
+    # An exception in the [[GetOwnProperty]] code path...
+    get_tree.GetOwnProperty = types.MethodType(lambda _a, _b: ThrowCompletion('Thrown from Get_01'), 'GetOwnProperty')
+    val = get_tree.Get('thimble', 345)
+    assert val == Completion(THROW, 'Thrown from Get_01', None)
+
+def test_object_Get_method_02(get_tree):
+    # An exception in the [[GetPrototypeOf]] code path...
+    get_tree.GetPrototypeOf = types.MethodType(lambda _: ThrowCompletion('Thrown from Get_02'), 'GetPrototypeOf')
+    val = get_tree.Get('needle', 345)
+    assert val == Completion(THROW, 'Thrown from Get_02', None)
+
+def test_object_Get_method_03(get_tree):
+    # Now try an exception from the parent's recursion.
+    parent = nc(get_tree.GetPrototypeOf())
+    parent.GetOwnProperty = types.MethodType(lambda _a, _b: ThrowCompletion('Thrown from Get_03'), 'GetOwnProperty')
+    val = get_tree.Get('haystack', 345)
+    assert val == Completion(THROW, 'Thrown from Get_03', None)


### PR DESCRIPTION
In particular, we now test:
  * `[[IsExtensible]]`
  * `[[PreventExtensions]]`
  * `[[GetOwnProperty]]`
  * `ValidateAndApplyPropertyDescriptor`
  * `[[DefineOwnProperty]]`
  * `[[HasProperty]]`
  * `[[Get]]`

Fixed:
  * How the instrinsics wind up in the global object (it was broken)
  * The spelling of the global property `NaN`
  * Spelling and grammar errors in text
  * Line length and other linter issues
  * Docstrings for object internal methods