### PR TITLE
Make a true SuperReference class

### DIFF
--- a/ecmascript.py
+++ b/ecmascript.py
@@ -1029,9 +1029,13 @@ class Reference:
         self.name = name
         self.strict = strict
     def __repr__(self):
-        if hasattr(self, 'this_value'):
-            return f'SuperReference({"S " if self.strict else ""}{self.name!r}, base={self.base!r}, thisValue={self.this_value!r})'
         return f'Reference({"S " if self.strict else ""}{self.name!r}, base={self.base!r})'
+class SuperReference(Reference):
+    def __init__(self, base, name, strict, this_value):
+        super().__init__(base, name, strict)
+        self.this_value = this_value
+    def __repr__(self):
+        return f'SuperReference({"S " if self.strict else ""}{self.name!r}, base={self.base!r}, thisValue={self.this_value!r})'
 
 # 6.2.4.1 GetBase ( V )
 def GetBase(value):

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -23,8 +23,7 @@ def test_reference_repr_02():
     assert 'S' not in val
 
 def test_reference_repr_03():
-    ref = Reference('base', 'super', False)
-    ref.this_value = 67
+    ref = SuperReference('base', 'super', False, 67)
     val = repr(ref)
     assert val.startswith('SuperReference(')
     assert 'thisValue=67' in val


### PR DESCRIPTION
Rather that just bastardize the attributes of Reference. This makes the linter a lot happier, and is probably also better code.