### PR TITLE
Add 'get' and 'set' as allowed identifier names

### DIFF
--- a/ecmascript.py
+++ b/ecmascript.py
@@ -6397,6 +6397,8 @@ class Lexer():
         'DIV',
         'DIVEQ',
         'TILDE',
+
+        # Reserved words. They may not be used as identifier names. (Although yield and await have special treatment.)
         'AWAIT', 'BREAK', 'CASE', 'CATCH', 'CLASS', 'CONST', 'CONTINUE',
         'DEBUGGER', 'DEFAULT', 'DELETE', 'DO', 'ELSE', 'EXPORT', 'EXTENDS',
         'FINALLY', 'FOR', 'FUNCTION', 'IF', 'IMPORT', 'IN', 'INSTANCEOF',
@@ -6404,7 +6406,9 @@ class Lexer():
         'VAR', 'VOID', 'WHILE', 'WITH', 'YIELD', 'ENUM', 'NULL', 'TRUE',
         'FALSE',
 
-        'OF', # Not marked as a ReservedWord in the spec, but it's used as one in for statements.
+        # Pseudo reserved words. They have particular meaning in some spots, but may still be used as identifier names.
+        # If you add something here, please update the 'Identifier' production in the parser class.
+        'OF', # Not marked as a ReservedWord in the spec, but it's used as a token in for statements.
         'LET', # Also not marked as a ReservedWord
         'SET',
         'GET',
@@ -17752,7 +17756,7 @@ class Ecma262Parser(Parser):
     def ReservedWord(self, p):
         return PN_ReservedWord(self.context, p)
 
-    @_('IDENTIFIER', 'OF', 'LET')  # pylint: disable=undefined-variable
+    @_('IDENTIFIER', 'OF', 'LET', 'SET', 'GET')  # pylint: disable=undefined-variable
     def Identifier(self, p):
         return PN_Identifier(self.context, p)
 

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -152,6 +152,8 @@ def cleanup():
     ("let s='',i=0;while(true){s+=i++;if(i>=10)break;}s;", '0123456789'),
     ("function mathme(a,b,c){return(a+b)*c;}mathme(1,2,3)*mathme(100,200,300);", 810000),
     ("let s=new String('hi');''+Object.defineProperty(s, '0', {value: 'h'});", 'hi'), # Should exercise IsCompatiblePropertyDescriptor
+    ('let get=3; get;', 3), # Make sure 'get' works as an identifier.
+    ('let set=4; set;', 4), # Make sure 'set' works as an identifier.
 ])
 def test_scripts_01(cleanup, script, result):
     rv = RunJobs(scripts=[script])


### PR DESCRIPTION
Since we recently changed them to pseudo-reserved words. Also added
comments in the section where those get added so that future me doesn't
forget to do this again.