### PR TITLE
Add tests for PropertyDefinition.PropName

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -7549,6 +7549,9 @@ class ParseNode2:
     def IsMissingInitializers(self, *args, **kwargs):
         return self.defer_target().IsMissingInitializers(*args, **kwargs)
 
+    def PropName(self, *args, **kwargs):
+        return self.defer_target().PropName(*args, **kwargs)
+
     def evaluate(self, *args, **kwargs):
         # Subclasses need to override this, or we'll throw an AttributeError when we hit a terminal.
         rval = self.defer_target().evaluate(*args, **kwargs)

--- a/tests/test_primary_expressions.py
+++ b/tests/test_primary_expressions.py
@@ -1934,6 +1934,24 @@ def test_PropertyDefinition_MethodDefinition_Contains(context, mocker, symbol, e
         pd.MethodDefinition.ComputedPropertyContains.assert_called_with(symbol)
 
 
+# 12.2.6.5 Static Semantics: PropName
+# PropertyDefinition : IdentifierReference
+#   1. Return StringValue of IdentifierReference.
+# PropertyDefinition : ... AssignmentExpression
+#   1. Return empty.
+# PropertyDefinition : PropertyName : AssignmentExpression
+#   1. Return PropName of PropertyName.
+@pytest.mark.parametrize(
+    "src, expected",
+    [("identifier_ref", "identifier_ref"), ("... 67", ecmascript.ecmascript.EMPTY), ('bluegill: "5 lbs."', "bluegill")],
+)
+def test_PropertyDefinition_PropName(context, src, expected):
+    lexer = lexer2.Lexer(src)
+    pd = ecmascript.ecmascript.parse_PropertyDefinition(context, lexer, False, False)
+    rv = pd.PropName()
+    assert rv == expected
+
+
 #### PropertyName ######################################################################################################
 #
 #     8888888b.                                             888             888b    888


### PR DESCRIPTION
Also fix PropName for the
	PropertyDefinition : PropertyName : AssignmentExpression
production. (We were missing the child-deferral path.)