### PR TITLE
Fix numeric literals that start with '.'

### DIFF
--- a/ecmascript/lexer2.py
+++ b/ecmascript/lexer2.py
@@ -413,14 +413,6 @@ class LexerCore:
                 identifier_name_early_errors(id_token, syntax_error_ctor=self.syntax_error_ctor)
                 return id_token
 
-            # Punctuator
-            punct = self.punctuator_match.match(self.src, pos=pos)
-            if punct:
-                span = punct.span()
-                return Token(
-                    type=punct.group(0), value=punct.group(0), src=self.src, span=Span(*span), newlines=newlines
-                )
-
             # NumericLiteral
             intconvert = lambda base: lambda span: int(self.src[span[0] + 2 : span[1]], base)
             for matcher, converter in (
@@ -435,6 +427,14 @@ class LexerCore:
                     return Token(
                         type="NUMERIC", src=self.src, value=converter(span), span=Span(*span), newlines=newlines
                     )
+
+            # Punctuator
+            punct = self.punctuator_match.match(self.src, pos=pos)
+            if punct:
+                span = punct.span()
+                return Token(
+                    type=punct.group(0), value=punct.group(0), src=self.src, span=Span(*span), newlines=newlines
+                )
 
             # StringLiteral
             for matcher in (self.doublestringliteral_match, self.singlestringliteral_match):

--- a/tests/test_lexer2.py
+++ b/tests/test_lexer2.py
@@ -168,6 +168,7 @@ class Test_LexerCore:
                 "InputElementRegExp",
                 lexer2.Token("NUMERIC", "899.31e-5", 0.0089931, lexer2.Span(0, 9), []),
             ),
+            (".25", 0, "InputElementRegExp", lexer2.Token("NUMERIC", ".25", 0.25, lexer2.Span(0, 3), [])),
             ('"string"', 0, "InputElementRegExp", lexer2.Token("STRING", '"string"', "string", lexer2.Span(0, 8), [])),
             ("", 0, "InputElementRegExp", None),
             ("}", 0, "InputElementDiv", lexer2.Token("}", "}", "}", lexer2.Span(0, 1), [])),


### PR DESCRIPTION
It turns out that when you match '.' as a punctuator before you try and
match as a floating point number, you don't actually get a floating
point number.

Switched the order of checks in the lexer to try numbers before
punctuation.