### PR TITLE
Fix name & length properties for the function prototype

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -28769,6 +28769,12 @@ def FunctionFixups(realm):
 
 
 def AttachFunctionPrototypeProperties(proto, realm):
+    DefinePropertyOrThrow(
+        proto, "length", PropertyDescriptor(value=0, writable=False, enumerable=False, configurable=True)
+    )
+    DefinePropertyOrThrow(
+        proto, "name", PropertyDescriptor(value="", writable=False, enumerable=False, configurable=True)
+    )
     BindBuiltinFunctions(
         realm,
         proto,

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -270,6 +270,7 @@ def cleanup():
         ("isNaN(88)", False),
         ("switch(1) { case 1: 2; break; }", 2),
         ("1; switch(1) { case 1: }", None),
+        ("delete eval.length; eval.length;", 0),
     ],
 )
 def test_scripts_01(cleanup, script, result):


### PR DESCRIPTION
Testing on one of the other functions made me realize that the "name"
and "length" properties on the function prototype were never created. So
here we are.

(The odd looking test removes a global function's "length" property so
that referencing it lets us look at the prototype's property instead.)