### PR TITLE
Fix property descriptors for global value properties

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -4231,7 +4231,7 @@ def SetDefaultGlobalBindings(realm_rec):
         #    attributes for the property. For properties listed in 18.2, 18.3, or 18.4 the value of the [[Value]]
         #    attribute is the corresponding intrinsic object from realmRec.
         # c. Perform ? DefinePropertyOrThrow(global, name, desc).
-        desc = PropertyDescriptor(value=value, writable=True, enumerable=False, configurable=True)
+        desc = PropertyDescriptor(value=value, writable=False, enumerable=False, configurable=False)
         DefinePropertyOrThrow(globl, name, desc)
     # 3. Return global.
     return globl

--- a/tests/test_toplevel.py
+++ b/tests/test_toplevel.py
@@ -275,6 +275,15 @@ def cleanup():
         ("parseInt(true, 36)", 1389110),
         ("''-4", -4),
         ("this.eval('1')", 1),
+        ("p = Object.getOwnPropertyDescriptor(this, 'NaN'); !p.writable && !p.enumerable && !p.configurable", True),
+        (
+            "p = Object.getOwnPropertyDescriptor(this, 'undefined'); !p.writable && !p.enumerable && !p.configurable",
+            True,
+        ),
+        (
+            "p = Object.getOwnPropertyDescriptor(this, 'Infinity'); !p.writable && !p.enumerable && !p.configurable",
+            True,
+        ),
     ],
 )
 def test_scripts_01(cleanup, script, result):


### PR DESCRIPTION
Previously, NaN, undefined, and Infinity were incorrectly writable and
configurable.