### PR TITLE
Fix strict mode for functions

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -24863,10 +24863,10 @@ def parse_FunctionDeclaration(context, lexer, strict, Yield, Await, Default):
                                 if rc:
                                     if bi:
                                         return P2_FunctionDeclaration_FUNCTION_BindingIdentifier_FormalParameters_FunctionBody(
-                                            context, strict, [function, bi, lp, fp, rp, lc, body, rc]
+                                            context, body.strict, [function, bi, lp, fp, rp, lc, body, rc]
                                         )
                                     return P2_FunctionDeclaration_FUNCTION_FormalParameters_FunctionBody(
-                                        context, strict, [function, lp, fp, rp, lc, body, rc]
+                                        context, body.strict, [function, lp, fp, rp, lc, body, rc]
                                     )
         lexer.reset_position(bookmark)
     return None
@@ -25075,10 +25075,10 @@ def parse_FunctionExpression(context, lexer, strict):
                             if rc:
                                 if bi:
                                     return P2_FunctionExpression_FUNCTION_BindingIdentifier_FormalParameters_FunctionBody(
-                                        context, strict, [function, bi, lp, fp, rp, lc, body, rc]
+                                        context, body.strict, [function, bi, lp, fp, rp, lc, body, rc]
                                     )
                                 return P2_FunctionExpression_FUNCTION_FormalParameters_FunctionBody(
-                                    context, strict, [function, lp, fp, rp, lc, body, rc]
+                                    context, body.strict, [function, lp, fp, rp, lc, body, rc]
                                 )
         lexer.reset_position(bookmark)
     return None
@@ -25613,7 +25613,7 @@ def parse_FunctionBody(context, lexer, strict, Yield, Await):
     #       FunctionStatementList[?Yield, ?Await]
     fsl = parse_FunctionStatementList(context, lexer, strict, Yield, Await)
     if fsl:
-        return P2_FunctionBody_FunctionStatementList(context, strict, [fsl])
+        return P2_FunctionBody_FunctionStatementList(context, fsl.strict, [fsl])
     return None
 
 
@@ -26137,7 +26137,7 @@ def parse_ConciseBody(context, lexer, strict, In):
         if fb:
             rc = lexer.next_token_if("}")
             if rc:
-                return P2_ConciseBody_FunctionBody(context, strict, [lc, fb, rc])
+                return P2_ConciseBody_FunctionBody(context, fb.strict, [lc, fb, rc])
     else:
         ae = parse_AssignmentExpression(context, lexer, strict, In, False, False)
         if ae:
@@ -26520,7 +26520,7 @@ def parse_MethodDefinition(context, lexer, strict, Yield, Await):
                             rc1 = lexer.next_token_if("}")
                             if rc1:
                                 return P2_MethodDefinition_PropertyName_UniqueFormalParameters_FunctionBody(
-                                    context, strict, [pn1, lp1, ufp, rp1, lc1, fb1, rc1]
+                                    context, fb1.strict, [pn1, lp1, ufp, rp1, lc1, fb1, rc1]
                                 )
         lexer.reset_position(bookmark)
     gm = parse_GeneratorMethod(context, lexer, strict, Yield, Await)
@@ -26547,7 +26547,7 @@ def parse_MethodDefinition(context, lexer, strict, Yield, Await):
                             rc_get = lexer.next_token_if("}")
                             if rc_get:
                                 return P2_MethodDefinition_GET_PropertyName_FunctionBody(
-                                    context, strict, [get, pn_get, lp_get, rp_get, lc_get, fb_get, rc_get]
+                                    context, fb_get.strict, [get, pn_get, lp_get, rp_get, lc_get, fb_get, rc_get]
                                 )
         lexer.reset_position(bookmark)
     set_tok = lexer.next_id_if("set")
@@ -26568,7 +26568,7 @@ def parse_MethodDefinition(context, lexer, strict, Yield, Await):
                                 if rc_set:
                                     return P2_MethodDefinition_SET_PropertyName_PropertySetParameterList_FunctionBody(
                                         context,
-                                        strict,
+                                        fb_set.strict,
                                         [set_tok, pn_set, lp_set, pspl, rp_set, lc_set, fb_set, rc_set],
                                     )
         lexer.reset_position(bookmark)
@@ -27192,7 +27192,7 @@ def parse_GeneratorBody(context, lexer, strict):
     #       FunctionBody[+Yield, ~Await]
     fb = parse_FunctionBody(context, lexer, strict, True, False)
     if fb:
-        return P2_GeneratorBody_FunctionBody(context, strict, [fb])
+        return P2_GeneratorBody_FunctionBody(context, fb.strict, [fb])
     return None
 
 

--- a/tests/test_parse2.py
+++ b/tests/test_parse2.py
@@ -257,6 +257,7 @@ def parser_mock(symbol, obj=None):
 class NotStringLiteral:
     IsStringLiteral = False
     HasUseStrict = False
+    strict = False
 
     def __init__(self, name):
         self.name = name
@@ -382,11 +383,13 @@ CATCH_PRODUCTION, catch_sideeffect = parser_mock("Catch")
 FINALLY_PRODUCTION, finally_sideeffect = parser_mock("Finally")
 CATCHPARAMETER, catchparameter_sideeffect = parser_mock("CatchParameter")
 FORMALPARAMETERS, formalparameters_sideeffect = parser_mock("FormalParameters")
-FUNCTIONBODY, functionbody_sideeffect = parser_mock("FunctionBody")
+FUNCTIONBODY, functionbody_sideeffect = parser_mock("FunctionBody", NotStringLiteral("FunctionBody"))
 FORMALPARAMETERLIST, formalparameterlist_sideeffect = parser_mock("FormalParameterList")
 FUNCTIONRESTPARAMETER, functionrestparameter_sideeffect = parser_mock("FunctionRestParameter")
 FORMALPARAMETER, formalparameter_sideeffect = parser_mock("FormalParameter")
-FUNCTIONSTATEMENTLIST, functionstatementlist_sideeffect = parser_mock("FunctionStatementList")
+FUNCTIONSTATEMENTLIST, functionstatementlist_sideeffect = parser_mock(
+    "FunctionStatementList", NotStringLiteral("FunctionStatementList")
+)
 ARROWPARAMETERS, arrowparameters_sideeffect = parser_mock("ArrowParameters")
 CONCISEBODY, concisebody_sideeffect = parser_mock("ConciseBody")
 (
@@ -10264,7 +10267,10 @@ class Test_FunctionDeclaration:
         fd = e.parse_FunctionDeclaration(context, lexer, "StrictArg", "YieldArg", "AwaitArg", Default)
         assert isinstance(fd, expected_class)
         for key in production_checks:
-            assert getattr(fd, key) == key, f"assert fd.{key} == {key!r}"
+            if hasattr(getattr(fd, key), "name"):
+                assert getattr(fd, key).name == key
+            else:
+                assert getattr(fd, key) == key, f"assert fd.{key} == {key!r}"
         for idx, expected in token_checks:
             assert fd.children[idx] == expected, f"assert fd.children[{idx}] == {expected!r}"
         assert lexer.pos == len(token_stream)
@@ -10415,7 +10421,10 @@ class Test_FunctionExpression:
         fe = e.parse_FunctionExpression(context, lexer, "StrictArg")
         assert isinstance(fe, expected_class)
         for key in production_checks:
-            assert getattr(fe, key) == key, f"assert fe.{key} == {key!r}"
+            if hasattr(getattr(fe, key), "name"):
+                assert getattr(fe, key).name == key
+            else:
+                assert getattr(fe, key) == key, f"assert fe.{key} == {key!r}"
         for idx, expected in token_checks:
             assert fe.children[idx] == expected, f"assert fe.children[{idx}] == {expected!r}"
         assert lexer.pos == len(token_stream)
@@ -10978,7 +10987,10 @@ class Test_FunctionBody:
         fb = e.parse_FunctionBody(context, lexer, "StrictArg", "YieldArg", "AwaitArg")
         assert isinstance(fb, expected_class)
         for key in production_checks:
-            assert getattr(fb, key) == key, f"assert fb.{key} == {key!r}"
+            if hasattr(getattr(fb, key), "name"):
+                assert getattr(fb, key).name == key
+            else:
+                assert getattr(fb, key) == key, f"assert fb.{key} == {key!r}"
         for idx, expected in token_checks:
             assert fb.children[idx] == expected, f"assert fb.children[{idx}] == {expected!r}"
         assert lexer.pos == len(token_stream)

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -174,11 +174,12 @@ class test262_testcase:
 
     def massaged(self, strict=False):
         result = ""
-        if strict:
-            result += '"use strict";\n'
-        for file in chain(("assert.js", "sta.js"), self.config["includes"]):
-            with open(os.path.join(self.root, "harness", file), "r") as f:
-                result += f.read() + "\n"
+        if "raw" not in self.config["flags"]:
+            if strict:
+                result += '"use strict";\n'
+            for file in chain(("assert.js", "sta.js"), self.config["includes"]):
+                with open(os.path.join(self.root, "harness", file), "r") as f:
+                    result += f.read() + "\n"
         result += self.source
         with open("test.js", "w") as f:
             print(result, file=f)
@@ -236,6 +237,8 @@ passing = (
     "language/asi",
     "language/block-scope",
     "language/comments",
+    "language/destructuring",
+    "language/directive-prologue",
     "language/eval-code",
     "language/identifier-resolution",
     "language/identifiers",
@@ -266,8 +269,8 @@ if test_passing:
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/String/**/*.js", recursive=True))
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/Array/**/*.js", recursive=True))
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/Object/**/*.js", recursive=True))
-# test_files.extend(glob.glob(f"{base_path}/test/built-ins/Symbol/**/*.js", recursive=True))
-# test_files.extend(glob.glob(f"{base_path}/test/language/computed-property-names/**/*.js", recursive=True))
+# test_files.extend(glob.glob(f"{base_path}/test/built-ins/Symbol/**/*.js", recursive=True)) # Needs Map
+# test_files.extend(glob.glob(f"{base_path}/test/language/computed-property-names/**/*.js", recursive=True)) # Needs NumberToString accuracy
 # test_files.extend(glob.glob(f"{base_path}/test/language/statements/class/**/*.js", recursive=True))
 test_files = [fn for fn in test_files if not fn.endswith("_FIXTURE.js")]
 
@@ -341,7 +344,10 @@ for tf in test_files:
             val
             for val, _ in filter(
                 itemgetter(1),
-                ((False, "onlyStrict" not in tc.config["flags"]), (True, "noStrict" not in tc.config["flags"])),
+                (
+                    (False, "onlyStrict" not in tc.config["flags"]),
+                    (True, all(x not in tc.config["flags"] for x in ("noStrict", "raw"))),
+                ),
             )
         ):
             params.append(


### PR DESCRIPTION
Needed to pass the strict flag up the parse tree as we built it;
functions were getting instantiated with the wrong strict value.