### PR TITLE
Fix syntax error tests

### DIFF
--- a/tests/test_destructuring.py
+++ b/tests/test_destructuring.py
@@ -6,14 +6,14 @@ from .helpers import *
 import ecmascript.ecmascript as ecmascript
 
 
-class Test_parse_ObjectAssignmentPattern:
+class Test_parse_ObjectAssignmentPattern(parse_test):
     # Syntax
     #   ObjectAssignmentPattern[Yield, Await]:
     #       { }
     #       { AssignmentRestProperty[?Yield, ?Await] }
     #       { AssignmentPropertyList[?Yield, ?Await] }
     #       { AssignmentPropertyList[?Yield, ?Await] , AssignmentRestProperty[?Yield, ?Await]opt }
-
+    target = staticmethod(ecmascript.parse_ObjectAssignmentPattern)
     OAP_Empty = ecmascript.P2_ObjectAssignmentPattern_Empty
     OAP_ARP = ecmascript.P2_ObjectAssignmentPattern_AssignmentRestProperty
     OAP_APL = ecmascript.P2_ObjectAssignmentPattern_AssignmentPropertyList
@@ -25,51 +25,19 @@ class Test_parse_ObjectAssignmentPattern:
         (("{", "AssignmentPropertyList", ",", "}"), OAP_APL),
         (("{", "AssignmentPropertyList", ",", "AssignmentRestProperty", "}"), OAP_APL_ARP),
     )
+    target_argnames = ("Yield", "Await")
+    called_argnames = {
+        "AssignmentRestProperty": ("?Yield", "?Await"),
+        "AssignmentPropertyList": ("?Yield", "?Await"),
+    }
 
-    @classmethod
-    def setup_prod_mocks(cls, mocker, token_stream, lex_pos):
-        return prod_mocks(
-            mocker,
-            token_stream,
-            lex_pos,
-            ecmascript.ParseNode2,
-            set(p for p in chain.from_iterable(prod for prod, ecls in cls.productions) if p[0].isupper()),
-        )
+    @ordinary_test_params(target_argnames, productions)
+    def test_ordinary(self, context, mocker, token_stream, expected_class, guard, lex_pos, strict_flag, prod_args):
+        self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
-    @pytest.mark.parametrize("strict_flag", (False, True))
-    @pytest.mark.parametrize("yield_flag", (False, True))
-    @pytest.mark.parametrize("await_flag", (False, True))
-    @pytest.mark.parametrize("lex_pos", (0, 10))
-    @pytest.mark.parametrize("token_stream, expected_class, guard", prod_streams(productions))
-    def test_ordinary(
-        self, mocker, context, strict_flag, yield_flag, await_flag, token_stream, expected_class, lex_pos, guard
-    ):
-        lexer = lexer_mock(mocker, token_stream, lex_pos)
-        productions = self.setup_prod_mocks(mocker, token_stream, lex_pos)
-
-        oap = ecmascript.parse_ObjectAssignmentPattern(context, lexer, lex_pos, strict_flag, yield_flag, await_flag)
-
-        assert isinstance(oap, expected_class)
-        for name, mock in productions.items():
-            if name in token_stream:
-                mock.assert_called_with(context, lexer, mocker.ANY, strict_flag, yield_flag, await_flag)
-        assert oap.strict == strict_flag
-        assert len(oap.children) == len(token_stream)
-        for idx, expected in enumerate(token_stream):
-            assert oap.children[idx].value == expected
-
-    @pytest.mark.parametrize("strict_flag", (False, True))
-    @pytest.mark.parametrize("yield_flag", (False, True))
-    @pytest.mark.parametrize("await_flag", (False, True))
-    @pytest.mark.parametrize("lex_pos", (0, 10))
-    @pytest.mark.parametrize("token_stream", synerror2_streams(prod for prod, ecls in productions))
-    def test_syntax_errors(self, mocker, context, strict_flag, yield_flag, await_flag, token_stream, lex_pos):
-        lexer = lexer_mock(mocker, token_stream, lex_pos)
-        self.setup_prod_mocks(mocker, token_stream, lex_pos)
-
-        oap = ecmascript.parse_ObjectAssignmentPattern(context, lexer, lex_pos, strict_flag, yield_flag, await_flag)
-
-        assert oap is None
+    @syntax_error_test_params(target_argnames, productions)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 ####################################################################################

--- a/tests/test_lhs.py
+++ b/tests/test_lhs.py
@@ -149,8 +149,8 @@ class Test_parse_MemberExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### SuperProperty ###################################################################################################
@@ -208,8 +208,8 @@ class Test_parse_SuperProperty(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### MetaProperty #############################################################################################
@@ -255,8 +255,8 @@ class Test_parse_MetaProperty(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### NewTarget ############################################################################
@@ -301,8 +301,8 @@ class Test_parse_NewTarget(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### NewExpression ########################################################################################################
@@ -358,8 +358,8 @@ class Test_parse_NewExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### CallExpression ################################################################################################
@@ -473,16 +473,8 @@ class Test_parse_CallExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(
-            mocker,
-            context,
-            strict_flag,
-            prod_args,
-            token_stream,
-            lex_pos,
-            recursive_expectation=("CoverCallExpressionAndAsyncArrowHead", self.CE_CCEAAAH),
-        )
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### SuperCall #########################################################################
@@ -528,8 +520,8 @@ class Test_parse_SuperCall(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### Arguments ##########################################################################
@@ -591,8 +583,8 @@ class Test_parse_Arguments(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ArgumentList ###########################################################################################
@@ -673,16 +665,8 @@ class Test_parse_ArgumentList(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(
-            mocker,
-            context,
-            strict_flag,
-            prod_args,
-            token_stream,
-            lex_pos,
-            recursive_expectation=("AssignmentExpression", self.AL_AE),
-        )
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### LefHandSideExpression #############################################################################################################################################################
@@ -741,8 +725,8 @@ class Test_parse_LeftHandSideExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### CallMemberExpression #########################################################################################################################################################
@@ -790,8 +774,8 @@ class Test_parse_CallMemberExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 ####################################################################################

--- a/tests/test_parse2.py
+++ b/tests/test_parse2.py
@@ -725,8 +725,8 @@ class Test_parse_UpdateExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### UnaryExpression ######################################################################################################################
@@ -847,8 +847,8 @@ class Test_parse_UnaryExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ExponentiationExpression ############################################################################################################################################################################
@@ -912,8 +912,8 @@ class Test_parse_ExponentiationExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### MultiplicativeExpression ################################################################################################################################################################
@@ -980,8 +980,8 @@ class Test_parse_MultiplicativeExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### MultiplicativeExpression #################################################################################################################################################
@@ -1041,8 +1041,8 @@ class Test_parse_MultiplicativeOperator(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### AdditiveExpression ################################################################################################################################
@@ -1118,8 +1118,8 @@ class Test_parse_AdditiveExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ShiftExpression #########################################################################################################
@@ -1218,8 +1218,8 @@ class Test_parse_ShiftExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### RelationalExpression #########################################################################################################################################
@@ -1340,8 +1340,8 @@ class Test_parse_RelationalExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### EqualityExpression ##############################################################################################################################
@@ -1439,8 +1439,8 @@ class Test_parse_EqualityExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### BitwiseANDExpression ############################################################################################################################################################

--- a/tests/test_primary_expressions.py
+++ b/tests/test_primary_expressions.py
@@ -87,8 +87,8 @@ class Test_parse_Literal(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 def test_PrimaryExpression_init(context):
@@ -272,8 +272,8 @@ class Test_parse_PrimaryExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### CoverParenthesizedExpressionAndArrowParameterList ##################################################################################################################################################################################################################################################################################################################################################################################################
@@ -414,8 +414,8 @@ class Test_parse_CoverParenthesizedExpressionAndArrowParameterList(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ParenthesizedExpression ##############################################################################################################################################################################
@@ -466,8 +466,8 @@ class Test_parse_ParenthesizedExpression(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### Elision ########################################################
@@ -522,8 +522,8 @@ class Test_parse_Elision(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ArrayLiteral #################################################################################
@@ -617,8 +617,8 @@ class Test_parse_ArrayLiteral(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ElementList #################################################################################
@@ -757,8 +757,8 @@ class Test_parse_ElementList(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### SpreadElement #########################################################################################################
@@ -809,8 +809,8 @@ class Test_parse_SpreadElement(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ObjectLiteral ######################################################################################
@@ -882,8 +882,8 @@ class Test_parse_ObjectLiteral(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### PropertyDefinitionList ######################################################################################################################################################
@@ -946,8 +946,8 @@ class Test_parse_PropertyDefinitionList(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### PropertyDefinition #############################################################################################################################
@@ -1047,8 +1047,8 @@ class Test_parse_PropertyDefinition(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### PropertyName ######################################################################################################
@@ -1103,8 +1103,8 @@ class Test_parse_PropertyName(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### LiteralPropertyName #################################################################################################################################################
@@ -1167,8 +1167,8 @@ class Test_parse_LiteralPropertyName(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### ComputedPropertyName #######################################################################################################################################################################
@@ -1220,8 +1220,8 @@ class Test_parse_ComputedPropertyName(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### CoverInitializedName ##############################################################################################################################################
@@ -1274,8 +1274,8 @@ class Test_parse_CoverInitializedName(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### Initializer ############################################################
@@ -1326,8 +1326,8 @@ class Test_parse_Initializer(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### TemplateLiteral ########################################################################################################
@@ -1386,8 +1386,8 @@ class Test_parse_TemplateLiteral(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### SubstitutionTemplate ###############################################################################################################################################
@@ -1445,8 +1445,8 @@ class Test_parse_SubstitutionTemplate(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### TemplateSpans #######################################################################################################
@@ -1510,8 +1510,8 @@ class Test_parse_TemplateSpans(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 #### TemplateMiddleList #################################################################################################################################
@@ -1590,8 +1590,8 @@ class Test_parse_TemplateMiddleList(parse_test):
         self.ordinary(mocker, context, token_stream, expected_class, guard, lex_pos, prod_args, strict_flag)
 
     @syntax_error_test_params(target_argnames, productions)
-    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos):
-        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos)
+    def test_syntax_errors(self, mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class):
+        self.syntax_errors(mocker, context, strict_flag, prod_args, token_stream, lex_pos, error_class)
 
 
 ####################################################################################


### PR DESCRIPTION
They were leaving out a significant percentage, causing my coverage
tests to report a lot of untested branches.