### PR TITLE
Fix the new.target tests by adding defered function calls

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -7998,6 +7998,12 @@ class ParseNode2:
     def LabelledEvaluation(self, *args, **kwargs):
         return self.defer_target().LabelledEvaluation(*args, **kwargs)
 
+    def HasDirectSuper(self, *args, **kwargs):
+        return self.defer_target().HasDirectSuper(*args, **kwargs)
+
+    def DefineMethod(self, *args, **kwargs):
+        return self.defer_target().DefineMethod(*args, **kwargs)
+
     def evaluate(self, *args, **kwargs):
         # Subclasses need to override this, or we'll throw an AttributeError when we hit a terminal.
         rval = self.defer_target().evaluate(*args, **kwargs)

--- a/tests/test_parse2.py
+++ b/tests/test_parse2.py
@@ -619,6 +619,8 @@ class Test_ParseNode2:
             "ContainsUseStrict",
             "AssignmentTargetType",
             "evaluate",
+            "HasDirectSuper",
+            "DefineMethod",
         ],
     )
     def test_deferred_calls(self, callname):

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -280,6 +280,7 @@ passing = (
     "language/expressions/logical-not",
     "language/expressions/logical-or",
     "language/expressions/multiplication",
+    "language/expressions/new.target",
     "language/expressions/void",
 )
 
@@ -297,7 +298,7 @@ if test_passing:
 #     test_files.extend(glob.glob(f"{base_path}/test/language/{suite}/**/*.js", recursive=True))
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/String/**/*.js", recursive=True))
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/Array/**/*.js", recursive=True))
-# test_files.extend(glob.glob(f"{base_path}/test/built-ins/Object/**/*.js", recursive=True))
+# test_files.extend(glob.glob(f"{base_path}/test/built-ins/Object/**/*.js", recursive=True)) # Needs Proxy
 # test_files.extend(glob.glob(f"{base_path}/test/built-ins/Symbol/**/*.js", recursive=True)) # Needs Map
 # test_files.extend(glob.glob(f"{base_path}/test/language/computed-property-names/**/*.js", recursive=True)) # 20 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/assignment/**/*.js", recursive=True)) # Needs Array.prototype.reduce
@@ -306,7 +307,7 @@ if test_passing:
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/delete/**/*.js", recursive=True)) # 4 failing (needs JSON)
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/class/**/*.js", recursive=True)) # 38 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/function/**/*.js", recursive=True))  # 14 failing
-# test_files.extend(glob.glob(f"{base_path}/test/language/expressions/left-shift/**/*.js", recursive=True))  # 8 failing
+# test_files.extend(glob.glob(f"{base_path}/test/language/expressions/left-shift/**/*.js", recursive=True))  # 8 failing (Hit python recursion limit)
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/modulus/**/*.js", recursive=True))  # 20 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/new/**/*.js", recursive=True))  # 16 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/object/**/*.js", recursive=True))  # 23 failing


### PR DESCRIPTION
Fixes test failures in the test262 suite "language/expressions/new.target"