### PR TITLE
Make the error message in EvaluateNew safer

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -11758,7 +11758,7 @@ def EvaluateNew(constructExpr, arguments):
     else:
         argList = arguments.ArgumentListEvaluation()
     if not IsConstructor(constructor):
-        raise ESTypeError(f"{GetReferencedName(ref)} is not a constructor")
+        raise ESTypeError(f"«{constructExpr.matched_source()}» is not a constructor")
     return Construct(constructor, argList)
 
 

--- a/tests/test_lhs.py
+++ b/tests/test_lhs.py
@@ -1358,11 +1358,12 @@ class Test_NewOperator_Evaluation:
 
     def test_EvaluateNew_03(self, context, mocker):
         # Isn't actually a constructor
-        ce = mocker.Mock(**{"evaluate.return_value": mocker.sentinel.ref})
+        ce = mocker.Mock(
+            **{"evaluate.return_value": mocker.sentinel.ref, "matched_source.return_value": "an invalid constructor"}
+        )
         ce.configure_mock(name="NewExpression")
         gv = mocker.patch("ecmascript.ecmascript.GetValue", return_value=mocker.sentinel.constructor)
         ic = mocker.patch("ecmascript.ecmascript.IsConstructor", return_value=False)
-        grn = mocker.patch("ecmascript.ecmascript.GetReferencedName", return_value="bob")
 
         with pytest.raises(e.ESTypeError):
             e.EvaluateNew(ce, e.EMPTY)
@@ -1370,7 +1371,6 @@ class Test_NewOperator_Evaluation:
         ce.evaluate.assert_called_with()
         gv.assert_called_with(mocker.sentinel.ref)
         ic.assert_called_with(mocker.sentinel.constructor)
-        grn.assert_called_with(mocker.sentinel.ref)
 
 
 ####################################################################################

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -281,6 +281,14 @@ passing = (
     "language/expressions/logical-or",
     "language/expressions/multiplication",
     "language/expressions/new.target",
+    "language/expressions/postfix-decrement",
+    "language/expressions/postfix-increment",
+    "language/expressions/prefix-decrement",
+    "language/expressions/prefix-increment",
+    "language/expressions/relational",
+    "language/expressions/strict-does-not-equals",
+    "language/expressions/strict-equals",
+    "language/expressions/subtraction",
     "language/expressions/void",
 )
 
@@ -311,6 +319,9 @@ if test_passing:
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/modulus/**/*.js", recursive=True))  # 20 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/new/**/*.js", recursive=True))  # 16 failing
 # test_files.extend(glob.glob(f"{base_path}/test/language/expressions/object/**/*.js", recursive=True))  # 23 failing
+# test_files.extend(glob.glob(f"{base_path}/test/language/expressions/property-accessors/**/*.js", recursive=True))  # 10 failing
+# test_files.extend(glob.glob(f"{base_path}/test/language/expressions/right-shift/**/*.js", recursive=True)) #  8 failing (Hit python recursion limit)
+# test_files.extend(glob.glob(f"{base_path}/test/language/expressions/super/**/*.js", recursive=True))  # 2 failing (Needs String.toLowerCase)
 test_files = [fn for fn in test_files if not fn.endswith("_FIXTURE.js")]
 
 features_to_avoid = (


### PR DESCRIPTION
Fixes the test262 suite: built-ins/String/S15.5.5_A2_T2.js

(Also update the passing tests list for the test262 runner.)