### PR TITLE
Fix the usage of bound function objects

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -6511,9 +6511,9 @@ class BoundFunctionObject(JSObject):
         boundArgs = self.BoundArguments
         # 4. Let args be a new list containing the same values as the list boundArgs in the same order followed by the same
         #    values as the list argumentsList in the same order.
-        args = boundArgs + argumentsList
+        args = boundArgs + tuple(argumentsList)
         # 5. Return ? Call(target, boundThis, args).
-        return Call(target, boundThis, *args)
+        return Call(target, boundThis, args)
 
 
 # 9.4.1.2 [[Construct]] ( argumentsList, newTarget )
@@ -6529,7 +6529,7 @@ def BoundFunction_Construct(self, argumentsList, newTarget):
     boundArgs = self.BoundArguments
     # 4. Let args be a new list containing the same values as the list boundArgs in the same order followed by the same values
     #    as the list argumentsList in the same order.
-    args = boundArgs + argumentsList
+    args = boundArgs + tuple(argumentsList)
     # 5. If SameValue(F, newTarget) is true, set newTarget to target.
     if SameValue(self, newTarget):
         newTarget = target

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 addopts = --cov --cov-config=tests/.coveragerc
 testpaths = tests
+xfail_strict=true

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -226,9 +226,10 @@ lang_tests = (
 )
 
 passing = (
-    # These paths have passed 100%. We shouldn't break them.
+    # These paths have passed (or xfailed, or skipped) 100%. We shouldn't break them.
     "built-ins/Boolean",
     "built-ins/Error",
+    "built-ins/Function/prototype/bind",
     "built-ins/isFinite",
     "built-ins/isNaN",
     "built-ins/parseFloat",
@@ -390,6 +391,11 @@ slow_tests = (
     "/test/language/comments/S7.4_A6.js",
 )
 
+xfail_tests = (
+    "/test/built-ins/Function/prototype/bind/15.3.4.5-2-7.js",  # Needs JSON object
+    "/test/built-ins/Function/prototype/bind/S15.3.4.5_A5.js",  # Needs Array.prototype.concat
+)
+
 
 def should_skip(tc, file_id):
     if not run_slow_tests and file_id in slow_tests:
@@ -401,6 +407,10 @@ def should_skip(tc, file_id):
     if any(flag in test_flags for flag in flags_to_avoid):
         return True
     return False
+
+
+def should_xfail(file_id):
+    return file_id in xfail_tests
 
 
 params = []
@@ -424,7 +434,7 @@ for tf in test_files:
                 strict,
                 tf,
                 id=f"{file_id}: {tc.config['description'].strip().splitlines()[0].strip()} [{'strict' if strict else 'loose'}]",
-                marks=pytest.mark.skip if skipit else (),
+                marks=pytest.mark.skip if skipit else (pytest.mark.xfail if should_xfail(file_id) else ()),
             )
         )
 


### PR DESCRIPTION
There were two problems:
  * a + b, where a was a tuple and b was a list (can't do that)
  * unpacking the arglist in Call() (need to pass it packed)

The Test-262 functions in
	test/built-ins/Function/prototype/bind
now pass, aside for the ones that depend on unwritten methods of other
global objects.