### PR TITLE
Fix the @@toStringTag for the global Math object

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -31601,7 +31601,7 @@ def CreateMathObject(realm):
             obj, name, PropertyDescriptor(value=value, writable=False, enumerable=False, configurable=False)
         )
     DefinePropertyOrThrow(
-        obj, wks_to_string_tag, PropertyDescriptor(vlaue="Math", writable=False, enumerable=False, configurable=True)
+        obj, wks_to_string_tag, PropertyDescriptor(value="Math", writable=False, enumerable=False, configurable=True)
     )
     BindBuiltinFunctions(
         realm,

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -230,6 +230,7 @@ passing = (
     "built-ins/Boolean",
     "built-ins/Error",
     "built-ins/Function/prototype/bind",
+    "built-ins/Math/Symbol.toStringTag.js",
     "built-ins/isFinite",
     "built-ins/isNaN",
     "built-ins/parseFloat",
@@ -301,7 +302,10 @@ base_path = base_paths[0]
 test_files = []
 if test_passing:
     for tst in passing:
-        test_files.extend(glob.glob(f"{base_path}/test/{tst}/**.js", recursive=True))
+        if tst.endswith(".js"):
+            test_files.append(f"{base_path}/test/{tst}")
+        else:
+            test_files.extend(glob.glob(f"{base_path}/test/{tst}/**.js", recursive=True))
 # test_files.extend(glob.glob(f"{base_path}/test/harness/*.js"))
 # for suite in lang_tests:
 #     test_files.extend(glob.glob(f"{base_path}/test/language/{suite}/**/*.js", recursive=True))


### PR DESCRIPTION
Now passing:
	* test/built-ins/Math/Symbol.toStringTag.js