### PR TITLE
Add String.prototype.split

### DIFF
--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -213,7 +213,7 @@ def test_CreateStringPrototype_03(realm):
         pytest.param("replace", "StringPrototype_replace", 2, marks=pytest.mark.xfail),
         pytest.param("search", "StringPrototype_search", 1, marks=pytest.mark.xfail),
         pytest.param("slice", "StringPrototype_slice", 2),
-        pytest.param("split", "StringPrototype_split", 2, marks=pytest.mark.xfail),
+        pytest.param("split", "StringPrototype_split", 2),
         pytest.param("startsWith", "StringPrototype_startsWith", 1, marks=pytest.mark.xfail),
         pytest.param("substring", "StringPrototype_substring", 2, marks=pytest.mark.xfail),
         pytest.param("toLocaleLowerCase", "StringPrototype_toLocaleLowerCase", 0, marks=pytest.mark.xfail),

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -231,6 +231,7 @@ passing = (
     "built-ins/Error",
     "built-ins/Function/prototype/bind",
     "built-ins/Math/Symbol.toStringTag.js",
+    "built-ins/String/prototype/split",
     "built-ins/isFinite",
     "built-ins/isNaN",
     "built-ins/parseFloat",
@@ -396,6 +397,14 @@ slow_tests = (
 )
 
 xfail_tests = (
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T20.js",  # Needs functional regex
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A1_T3.js",  # Needs String.prototype.substring
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A2_T20.js",  # Needs String.prototype.charAt
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A2_T6.js",  # Needs String.prototype.charAt
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A3_T3.js",  # Needs String.prototype.substring
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T19.js",  # Needs functional regex
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T22.js",  # Needs functional regex
+    "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T23.js",  # Needs functional regex
     "/test/built-ins/Function/prototype/bind/15.3.4.5-2-7.js",  # Needs JSON object
     "/test/built-ins/Function/prototype/bind/S15.3.4.5_A5.js",  # Needs Array.prototype.concat
 )


### PR DESCRIPTION
All of the tests in the Test-262 test suite with the path `test/built-ins/String/prototype/split` now pass with the exception of the following:

Needs regex class escapes to actually work:
* S15.5.4.14_A4_T20.js
* S15.5.4.14_A4_T19.js
* S15.5.4.14_A4_T22.js
* S15.5.4.14_A4_T23.js

Needs `String.prototype.charAt`:
* S15.5.4.14_A2_T20.js
* S15.5.4.14_A2_T6.js

Needs `String.prototype.substring`:
* S15.5.4.14_A1_T3.js
* S15.5.4.14_A3_T3.js