### PR TITLE
Fix String.prototype.indexOf which was mishandling its args

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -33589,7 +33589,7 @@ def StringPrototype_indexOf(this_value, new_target, searchString=None, position=
     S = ToString(RequireObjectCoercible(this_value))
     searchStr = ToString(searchString)
     pos = ToInteger(position)
-    start = min(max(pos, 0), len(S))
+    start = int(min(max(pos, 0), len(S)))
     try:
         return S.index(searchStr, start)
     except ValueError:

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -231,6 +231,7 @@ passing = (
     "built-ins/Error",
     "built-ins/Function/prototype/bind",
     "built-ins/Math/Symbol.toStringTag.js",
+    "built-ins/String/prototype/indexOf",
     "built-ins/String/prototype/split",
     "built-ins/isFinite",
     "built-ins/isNaN",
@@ -397,6 +398,7 @@ slow_tests = (
 )
 
 xfail_tests = (
+    "/test/built-ins/String/prototype/indexOf/S15.5.4.7_A1_T12.js",  # Needs Array.prototype.indexOf
     "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T20.js",  # Needs functional regex
     "/test/built-ins/String/prototype/split/S15.5.4.14_A1_T3.js",  # Needs String.prototype.substring
     "/test/built-ins/String/prototype/split/S15.5.4.14_A2_T20.js",  # Needs String.prototype.charAt


### PR DESCRIPTION
In partuclar, `ToInteger()` integer-ifies its argument, but still returns a float. Before passing to the Python `index` method, a real type conversion was needed.

All the Test-262 tests in `test/built-ins/String/prototype/indexOf` now pass, with the exception of

Needs `Array.prototype.indexOf`:
* S15.5.4.7_A1_T12.js