### PR TITLE
Add `String.prototype.charAt`

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -33538,6 +33538,7 @@ def CreateStringPrototype(realm):
         realm,
         string_prototype,
         (
+            ("charAt", StringPrototype_charAt, None),
             ("indexOf", StringPrototype_indexOf, None),
             ("slice", StringPrototype_slice, None),
             ("split", StringPrototype_split, None),
@@ -33563,6 +33564,38 @@ def thisStringValue(value):
         return value.StringData
     raise ESTypeError("Not a string value")
 
+
+# 21.1.3.1 String.prototype.charAt ( pos )
+def StringPrototype_charAt(this_value, new_target, pos=None, *_):
+    # NOTE 1    | Returns a single element String containing the code unit at index pos within the String value
+    #           | resulting from converting this object to a String. If there is no element at that index, the
+    #           | result is the empty String. The result is a String value, not a String object.
+    #           |
+    #           | If pos is a value of Number type that is an integer, then the result of x.charAt(pos) is equal to
+    #           | the result of x.substring(pos, pos + 1).
+    #
+    # When the charAt method is called with one argument pos, the following steps are taken:
+    #
+    #   1. Let O be ? RequireObjectCoercible(this value).
+    #   2. Let S be ? ToString(O).
+    #   3. Let position be ? ToInteger(pos).
+    #   4. Let size be the length of S.
+    #   5. If position < 0 or position ≥ size, return the empty String.
+    #   6. Return the String value of length 1, containing one code unit from S, namely the code unit at index
+    #      position.
+    # NOTE 2    | The charAt function is intentionally generic; it does not require that its this value be a String
+    #           | object. Therefore, it can be transferred to other kinds of objects for use as a method.
+    O = RequireObjectCoercible(this_value)
+    S = ToString(O)
+    position = ToInteger(pos)
+    size = len(S)
+    if position < 0 or position >= size:
+        return ""
+    return S[int(position)]
+
+
+StringPrototype_charAt.name = "charAt"
+StringPrototype_charAt.length = 1
 
 # 21.1.3.8 String.prototype.indexOf ( searchString [ , position ] )
 def StringPrototype_indexOf(this_value, new_target, searchString=None, position=None, *_):

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -196,7 +196,7 @@ def test_CreateStringPrototype_03(realm):
 @pytest.mark.parametrize(
     "fname, fcn, length",
     [
-        pytest.param("charAt", "StringPrototype_charAt", 1, marks=pytest.mark.xfail),
+        pytest.param("charAt", "StringPrototype_charAt", 1),
         pytest.param("charCodeAt", "StringPrototype_charCodeAt", 1, marks=pytest.mark.xfail),
         pytest.param("codePointAt", "StringPrototype_codePointAt", 1, marks=pytest.mark.xfail),
         pytest.param("concat", "StringPrototype_concat", 1, marks=pytest.mark.xfail),

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -231,8 +231,12 @@ passing = (
     "built-ins/Error",
     "built-ins/Function/prototype/bind",
     "built-ins/Math/Symbol.toStringTag.js",
+    "built-ins/String/prototype/charAt",
     "built-ins/String/prototype/indexOf",
+    "built-ins/String/prototype/slice",
     "built-ins/String/prototype/split",
+    "built-ins/String/prototype/toString",
+    "built-ins/String/prototype/valueOf",
     "built-ins/isFinite",
     "built-ins/isNaN",
     "built-ins/parseFloat",
@@ -398,15 +402,18 @@ slow_tests = (
 )
 
 xfail_tests = (
+    "/test/built-ins/String/prototype/charAt/S15.5.4.4_A4_T1.js",  # Needs String.prototype.substring
+    "/test/built-ins/String/prototype/charAt/S15.5.4.4_A4_T2.js",  # Needs String.prototype.substring
+    "/test/built-ins/String/prototype/charAt/S15.5.4.4_A4_T3.js",  # Needs String.prototype.substring
     "/test/built-ins/String/prototype/indexOf/S15.5.4.7_A1_T12.js",  # Needs Array.prototype.indexOf
     "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T20.js",  # Needs functional regex
     "/test/built-ins/String/prototype/split/S15.5.4.14_A1_T3.js",  # Needs String.prototype.substring
-    "/test/built-ins/String/prototype/split/S15.5.4.14_A2_T20.js",  # Needs String.prototype.charAt
-    "/test/built-ins/String/prototype/split/S15.5.4.14_A2_T6.js",  # Needs String.prototype.charAt
     "/test/built-ins/String/prototype/split/S15.5.4.14_A3_T3.js",  # Needs String.prototype.substring
     "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T19.js",  # Needs functional regex
     "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T22.js",  # Needs functional regex
     "/test/built-ins/String/prototype/split/S15.5.4.14_A4_T23.js",  # Needs functional regex
+    "/test/built-ins/String/prototype/toString/non-generic-realm.js",  # Needs String.prototype.concat
+    "/test/built-ins/String/prototype/toString/string-object.js",  # Needs String.prototype.concat
     "/test/built-ins/Function/prototype/bind/15.3.4.5-2-7.js",  # Needs JSON object
     "/test/built-ins/Function/prototype/bind/S15.3.4.5_A5.js",  # Needs Array.prototype.concat
 )


### PR DESCRIPTION
Now all the tests in Test-262 with the path `test/built-ins/String/prototype/charAt` pass with the exception of:

Needs `String.prototype.substring`:
* S15.5.4.4_A4_T1.js
* S15.5.4.4_A4_T2.js
* S15.5.4.4_A4_T3.js

Also completed the exception lists for other String functions that hadn't been connected with test-262 before.