### PR TITLE
Fix the constructor property descriptors

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -30146,7 +30146,7 @@ def AddObjectPrototypeProps(realm_rec):
     DefinePropertyOrThrow(
         obj,
         "constructor",
-        PropertyDescriptor(value=intrinsics["%Object%"], writable=False, enumerable=False, configurable=False),
+        PropertyDescriptor(value=intrinsics["%Object%"], writable=True, enumerable=False, configurable=True),
     )
     BindBuiltinFunctions(
         realm_rec,
@@ -30590,7 +30590,11 @@ def FunctionFixups(realm):
         "prototype",
         PropertyDescriptor(value=prototype, writable=False, enumerable=False, configurable=False),
     )
-    DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor(value=constructor))
+    DefinePropertyOrThrow(
+        prototype,
+        "constructor",
+        PropertyDescriptor(value=constructor, writable=True, enumerable=False, configurable=True),
+    )
     return None
 
 
@@ -30858,7 +30862,11 @@ def BooleanFixups(realm):
         "prototype",
         PropertyDescriptor(value=boolean_prototype, writable=False, enumerable=False, configurable=False),
     )
-    DefinePropertyOrThrow(boolean_prototype, "constructor", PropertyDescriptor(value=boolean_constructor))
+    DefinePropertyOrThrow(
+        boolean_prototype,
+        "constructor",
+        PropertyDescriptor(value=boolean_constructor, writable=True, enumerable=False, configurable=True),
+    )
     return None
 
 
@@ -31237,7 +31245,11 @@ def ErrorFixups(realm):
     )
     # 19.5.3.1 Error.prototype.constructor
     # The initial value of Error.prototype.constructor is the intrinsic object %Error%.
-    DefinePropertyOrThrow(error_prototype, "constructor", PropertyDescriptor(value=error_constructor))
+    DefinePropertyOrThrow(
+        error_prototype,
+        "constructor",
+        PropertyDescriptor(value=error_constructor, writable=True, enumerable=False, configurable=True),
+    )
     return None
 
 
@@ -31325,7 +31337,11 @@ def NativeErrorFixups(realm):
             "prototype",
             PropertyDescriptor(value=prototype, writable=False, enumerable=False, configurable=False),
         )
-        DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor(value=constructor))
+        DefinePropertyOrThrow(
+            prototype,
+            "constructor",
+            PropertyDescriptor(value=constructor, writable=True, enumerable=False, configurable=True),
+        )
     return None
 
 
@@ -31591,7 +31607,11 @@ def NumberFixups(realm):
     number_prototype = realm.intrinsics["%NumberPrototype%"]
     proto_desc = PropertyDescriptor(value=number_prototype, writable=False, enumerable=False, configurable=False)
     DefinePropertyOrThrow(number_constructor, "prototype", proto_desc)
-    DefinePropertyOrThrow(number_prototype, "constructor", PropertyDescriptor(value=number_constructor))
+    DefinePropertyOrThrow(
+        number_prototype,
+        "constructor",
+        PropertyDescriptor(value=number_constructor, writable=True, enumerable=False, configurable=True),
+    )
     return None
 
 
@@ -33341,7 +33361,11 @@ def DateFixups(realm):
     date_prototype = realm.intrinsics["%DatePrototype%"]
     proto_desc = PropertyDescriptor(value=date_prototype, writable=False, enumerable=False, configurable=False)
     DefinePropertyOrThrow(date_constructor, "prototype", proto_desc)
-    DefinePropertyOrThrow(date_prototype, "constructor", PropertyDescriptor(value=date_constructor))
+    DefinePropertyOrThrow(
+        date_prototype,
+        "constructor",
+        PropertyDescriptor(value=date_constructor, writable=True, enumerable=False, configurable=True),
+    )
     return None
 
 
@@ -34218,12 +34242,12 @@ def RegExpFixups(realm: Realm) -> None:
     # 21.2.4.1 RegExp.prototype
     # The initial value of RegExp.prototype is the intrinsic object %RegExpPrototype%.
     # This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
-    proto_desc = PropertyDescriptor(value=regexp_prototype, writable=False, enumerable=False, Configurable=False)
+    proto_desc = PropertyDescriptor(value=regexp_prototype, writable=False, enumerable=False, configurable=False)
     DefinePropertyOrThrow(regexp_constructor, "prototype", proto_desc)
     # 21.2.5.1 RegExp.prototype.constructor
     # The initial value of RegExp.prototype.constructor is the intrinsic object %RegExp%.
     constructor_desc = PropertyDescriptor(
-        value=regexp_constructor, writable=True, enumerable=False, Configurable=True
+        value=regexp_constructor, writable=True, enumerable=False, configurable=True
     )
     DefinePropertyOrThrow(regexp_prototype, "constructor", constructor_desc)
 
@@ -36985,7 +37009,9 @@ def CreateSpecificTypedArrayPrototype(realm: Realm, name: str):
 def SpecificTypedArrayFixups(realm: Realm, name: str):
     proto = realm.intrinsics[f"%{name}Prototype%"]
     cstr = realm.intrinsics[f"%{name}%"]
-    DefinePropertyOrThrow(proto, "constructor", PropertyDescriptor(value=cstr))
+    DefinePropertyOrThrow(
+        proto, "constructor", PropertyDescriptor(value=cstr, writable=True, enumerable=False, configurable=True)
+    )
     DefinePropertyOrThrow(
         cstr, "prototype", PropertyDescriptor(value=proto, writable=False, enumerable=False, configurable=False)
     )
@@ -37483,7 +37509,11 @@ def ArrayBufferFixups(realm):
         "prototype",
         PropertyDescriptor(value=prototype, writable=False, enumerable=False, configurable=False),
     )
-    DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor(value=constructor))
+    DefinePropertyOrThrow(
+        prototype,
+        "constructor",
+        PropertyDescriptor(value=constructor, writable=True, enumerable=False, configurable=True),
+    )
 
 
 ######################################################################################################################################################################################################################################################################

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -468,20 +468,8 @@ xfail_tests = (
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-11.js",  # Needs encodeURIComponent
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-114.js",  # Needs Date.parse
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-115.js",  # Needs Date.UTC
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-116.js",  # Needs Date.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-163.js",  # Needs RegExp.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-168.js",  # Needs Error.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-170.js",  # Needs EvalError.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-171.js",  # Needs RangeError.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-172.js",  # Needs ReferenceError.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-173.js",  # Needs SyntaxError.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-174.js",  # Needs TypeError.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-175.js",  # Needs URIError.prototype.constructor
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-176.js",  # Needs JSON
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-177.js",  # Needs JSON
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-27.js",  # Needs Object.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-34.js",  # Needs Function.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-39.js",  # Needs Array.prototype.constructor
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-40.js",  # Needs Array.prototype.concat
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-42.js",  # Needs Array.prototype.reverse
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-44.js",  # Needs Array.prototype.sort
@@ -497,7 +485,6 @@ xfail_tests = (
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-58.js",  # Needs Array.prototype.filter
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-59.js",  # Needs Array.prototype.reduce
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-60.js",  # Needs Array.prototype.reduceRight
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-62.js",  # Needs String.prototype.constructor
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-64.js",  # Needs String.prototype.charCodeAt
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-67.js",  # Needs String.prototype.lastIndexOf
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-68.js",  # Needs String.prototype.match
@@ -509,8 +496,6 @@ xfail_tests = (
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-80.js",  # Needs String.prototype.toLocaleUpperCase
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-81.js",  # Needs String.prototype.localeCompare
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-82.js",  # Needs String.prototype.trim
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-84.js",  # Needs Boolean.prototype.constructor
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-88.js",  # Needs Number.prototype.constructor
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-9.js",  # Needs decodeURI
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-90.js",  # Needs Number.prototype.toLocaleString
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-91.js",  # Needs Number.prototype.toFixed


### PR DESCRIPTION
I had them all wrong.

Fixed the prototype property descriptor for the RegExp global as well.

All the object tests I had previously labeled "needs constructor" are now passing.