### PR TITLE
Fix strict parameters in Function constructor

### DIFF
--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -404,7 +404,6 @@ xfail_tests = (
     "/test/harness/deepEqual-object.js",  # Needs Map
     "/test/harness/deepEqual-primitives.js",  # Needs Map
     "/test/harness/timer.js",  # Needs Promise
-    "/test/built-ins/Function/15.3.2.1-11-3-s.js",  # Needs to have arguments parsed after body, so use-strict can be known already. In CreateDynamicFunction.
     "/test/built-ins/Function/prototype/bind/15.3.4.5-2-7.js",  # Needs JSON object
     "/test/built-ins/Function/prototype/bind/S15.3.4.5_A5.js",  # Needs Array.prototype.concat
     "/test/built-ins/Function/prototype/toString/built-in-function-object.js",  # Needs Generators


### PR DESCRIPTION
So it turns out that if you want the function constructor to parse its text in strict mode based on whether the function body is strict or not, you actually need to parse the function body first.

Also: fix error reporter callback: we were over-encapsulating our errors from that parsing.

Fixes #319
The following Test-262 tests now pass:
* built-ins/Function/15.3.2.1-11-3-s.js