### PR TITLE
Add IsIdentifierRef to the deferred-targets list

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -8042,6 +8042,9 @@ class ParseNode2:
     def DefineMethod(self, *args, **kwargs):
         return self.defer_target().DefineMethod(*args, **kwargs)
 
+    def IsIdentifierRef(self, *args, **kwargs):
+        return self.defer_target().IsIdentifierRef(*args, **kwargs)
+
     def evaluate(self, *args, **kwargs):
         # Subclasses need to override this, or we'll throw an AttributeError when we hit a terminal.
         rval = self.defer_target().evaluate(*args, **kwargs)

--- a/tests/test_parse2.py
+++ b/tests/test_parse2.py
@@ -621,6 +621,7 @@ class Test_ParseNode2:
             "evaluate",
             "HasDirectSuper",
             "DefineMethod",
+            "IsIdentifierRef",
         ],
     )
     def test_deferred_calls(self, callname):

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -966,10 +966,6 @@ xfail_tests = (
     "/test/language/computed-property-names/class/static/method-symbol.js",  # Wants default anonymous function naming
     "/test/language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order.js",  # Fix pending
     "/test/language/expressions/assignment/destructuring/obj-prop-__proto__dup.js",  # Fix pending
-    "/test/language/expressions/assignment/dstr/array-elem-init-fn-name-arrow.js",  # Fix pending
-    "/test/language/expressions/assignment/dstr/array-elem-init-fn-name-class.js",  # Fix pending
-    "/test/language/expressions/assignment/dstr/array-elem-init-fn-name-cover.js",  # Fix pending
-    "/test/language/expressions/assignment/dstr/array-elem-init-fn-name-fn.js",  # Fix pending
     "/test/language/expressions/assignment/dstr/array-elem-iter-thrw-close-err.js",  # Needs a functional IteratorClose
     "/test/language/expressions/assignment/dstr/array-elem-iter-thrw-close.js",  # Needs a functional IteratorClose
     "/test/language/expressions/assignment/dstr/array-elem-nested-array-invalid.js",  # Something is Wrong
@@ -1088,7 +1084,6 @@ xfail_tests = (
     "/test/language/expressions/assignment/dstr/obj-id-init-let.js",  # Fix pending
     "/test/language/expressions/assignment/dstr/obj-id-init-order.js",  # Fix pending
     "/test/language/expressions/assignment/dstr/obj-id-init-simple-no-strict.js",  # Fix pending
-    "/test/language/expressions/assignment/dstr/obj-id-init-simple-strict.js",  # ???
     "/test/language/expressions/assignment/dstr/obj-id-init-yield-ident-valid.js",  # Fix pending
     "/test/language/expressions/assignment/dstr/obj-id-put-const.js",  # Fix pending
     "/test/language/expressions/assignment/dstr/obj-id-put-let.js",  # Fix pending


### PR DESCRIPTION
Fixes

* language/expressions/assignment/dstr/array-elem-init-fn-name-arrow.js
* language/expressions/assignment/dstr/array-elem-init-fn-name-class.js
* language/expressions/assignment/dstr/array-elem-init-fn-name-cover.js
* language/expressions/assignment/dstr/array-elem-init-fn-name-fn.js
* language/expressions/assignment/dstr/obj-id-init-simple-strict.js