### PR TITLE
Fix separator=undefined in Array.prototype.join

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -35569,7 +35569,7 @@ ArrayPrototype_forEach.length = 1
 ArrayPrototype_forEach.name = "forEach"
 
 # 22.1.3.15 Array.prototype.join ( separator )
-def ArrayPrototype_join(this_value, new_target, separator=",", *_):
+def ArrayPrototype_join(this_value, new_target, separator=None, *_):
     # NOTE 1
     # The elements of the array are converted to Strings, and these Strings are then concatenated, separated by
     # occurrences of the separator. If no separator is provided, a single comma is used as the separator.
@@ -35595,7 +35595,7 @@ def ArrayPrototype_join(this_value, new_target, separator=",", *_):
     # Therefore, it can be transferred to other kinds of objects for use as a method.
     O = ToObject(this_value)
     length = ToLength(Get(O, "length"))
-    sep = ToString(separator)
+    sep = ToString(separator) if separator is not None else ","
     return sep.join(
         ToString(element) if not (isUndefined(element) or isNull(element)) else ""
         for element in (Get(O, ToString(k)) for k in range(length))

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -411,8 +411,6 @@ xfail_tests = (
     "/test/harness/deepEqual-object.js",  # Needs Map
     "/test/harness/deepEqual-primitives.js",  # Needs Map
     "/test/harness/timer.js",  # Needs Promise
-    "/test/built-ins/Array/prototype/join/S15.4.4.5_A1.2_T2.js",  # Bug in join
-    "/test/built-ins/Array/prototype/join/S15.4.4.5_A3.1_T1.js",  # Bug in join
     "/test/built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js",  # Bug in map
     "/test/built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js",  # Bug in slice
     "/test/built-ins/Array/prototype/slice/length-exceeding-integer-limit-proxied-array.js",  # Bug in slice


### PR DESCRIPTION
The following tests now pass:

* /built-ins/Array/prototype/join/S15.4.4.5_A1.2_T2.js
* /built-ins/Array/prototype/join/S15.4.4.5_A3.1_T1.js