### PR TITLE
Add String.prototype.padEnd

### DIFF
--- a/ecmascript/ecmascript.py
+++ b/ecmascript/ecmascript.py
@@ -33749,6 +33749,7 @@ def CreateStringPrototype(realm):
             ("localeCompare", StringPrototype_localeCompare, None),
             ("match", StringPrototype_match, None),
             ("normalize", StringPrototype_normalize, None),
+            ("padEnd", StringPrototype_padEnd, None),
             ("slice", StringPrototype_slice, None),
             ("split", StringPrototype_split, None),
             ("substring", StringPrototype_substring, None),
@@ -34196,6 +34197,49 @@ def StringPrototype_normalize(this_value, new_target, form=None, *_):
 
 StringPrototype_normalize.name = "normalize"
 StringPrototype_normalize.length = 0
+
+# 21.1.3.13 String.prototype.padEnd ( maxLength [ , fillString ] )
+def StringPrototype_padEnd(this_value, new_target, maxLength=None, fillString=None, *_):
+    # When the padEnd method is called, the following steps are taken:
+    #
+    #   1. Let O be ? RequireObjectCoercible(this value).
+    #   2. Let S be ? ToString(O).
+    #   3. Let intMaxLength be ? ToLength(maxLength).
+    #   4. Let stringLength be the length of S.
+    #   5. If intMaxLength is not greater than stringLength, return S.
+    #   6. If fillString is undefined, let filler be the String value consisting solely of the code unit 0x0020
+    #      (SPACE).
+    #   7. Else, let filler be ? ToString(fillString).
+    #   8. If filler is the empty String, return S.
+    #   9. Let fillLen be intMaxLength - stringLength.
+    #   10. Let truncatedStringFiller be the String value consisting of repeated concatenations of filler truncated
+    #       to length fillLen.
+    #   11. Return the string-concatenation of S and truncatedStringFiller.
+    #
+    # NOTE 1    | The first argument maxLength will be clamped such that it can be no smaller than the length of the
+    #           | this value.
+    #
+    # NOTE 2    | The optional second argument fillString defaults to " " (the String value consisting of the code
+    #           | unit 0x0020 SPACE).
+    O = RequireObjectCoercible(this_value)
+    S = ToString(O)
+    intMaxLength = int(ToLength(maxLength))
+    stringLength = len(S)
+    if intMaxLength <= stringLength:
+        return S
+    if fillString is None:
+        filler = " "
+    else:
+        filler = ToString(fillString)
+    if filler == "":
+        return S
+    fillLen = intMaxLength - stringLength
+    truncatedStringFiller = (filler * int((fillLen + len(filler) - 1) / len(filler)))[:fillLen]
+    return f"{S}{truncatedStringFiller}"
+
+
+StringPrototype_padEnd.name = "padEnd"
+StringPrototype_padEnd.length = 1
 
 # 21.1.3.18 String.prototype.slice ( start, end )
 def StringPrototype_slice(this_value, new_target, start=None, end=None, *_):

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -207,7 +207,7 @@ def test_CreateStringPrototype_03(realm):
         ("localeCompare", "StringPrototype_localeCompare", 1),
         ("match", "StringPrototype_match", 1),
         ("normalize", "StringPrototype_normalize", 0),
-        pytest.param("padEnd", "StringPrototype_padEnd", 1, marks=pytest.mark.xfail),
+        ("padEnd", "StringPrototype_padEnd", 1),
         pytest.param("padStart", "StringPrototype_padStart", 1, marks=pytest.mark.xfail),
         pytest.param("repeat", "StringPrototype_repeat", 1, marks=pytest.mark.xfail),
         pytest.param("replace", "StringPrototype_replace", 2, marks=pytest.mark.xfail),

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -510,16 +510,6 @@ xfail_tests = (
     "/test/built-ins/String/prototype/match/S15.5.4.10_A2_T4.js",  # Needs regex character class
     "/test/built-ins/String/prototype/match/S15.5.4.10_A2_T5.js",  # Needs regex character class
     "/test/built-ins/String/prototype/match/this-value-not-obj-coercible.js",  # Needs regex character class
-    "/test/built-ins/String/prototype/padEnd/exception-not-object-coercible.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/fill-string-empty.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/fill-string-non-strings.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/fill-string-omitted.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/function-length.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/function-name.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/function-property-descriptor.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/max-length-not-greater-than-string.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/normal-operation.js",  # Needs String.prototype.padEnd
-    "/test/built-ins/String/prototype/padEnd/observable-operations.js",  # Needs String.prototype.padEnd
     "/test/built-ins/String/prototype/padStart/exception-not-object-coercible.js",  # Needs String.prototype.padStart
     "/test/built-ins/String/prototype/padStart/fill-string-empty.js",  # Needs String.prototype.padStart
     "/test/built-ins/String/prototype/padStart/fill-string-non-strings.js",  # Needs String.prototype.padStart


### PR DESCRIPTION
The `padEnd()` method pads the current string with a given string (repeated, if needed) so that the resulting string reaches a given length. The padding is applied from the end of the current string.

[Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd)