### PR TITLE
Add String.prototype.replace

### DIFF
--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -210,7 +210,7 @@ def test_CreateStringPrototype_03(realm):
         ("padEnd", "StringPrototype_padEnd", 1),
         ("padStart", "StringPrototype_padStart", 1),
         ("repeat", "StringPrototype_repeat", 1),
-        pytest.param("replace", "StringPrototype_replace", 2, marks=pytest.mark.xfail),
+        ("replace", "StringPrototype_replace", 2),
         pytest.param("search", "StringPrototype_search", 1, marks=pytest.mark.xfail),
         ("slice", "StringPrototype_slice", 2),
         ("split", "StringPrototype_split", 2),

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -510,47 +510,10 @@ xfail_tests = (
     "/test/built-ins/String/prototype/match/S15.5.4.10_A2_T4.js",  # Needs regex character class
     "/test/built-ins/String/prototype/match/S15.5.4.10_A2_T5.js",  # Needs regex character class
     "/test/built-ins/String/prototype/match/this-value-not-obj-coercible.js",  # Needs regex character class
-    "/test/built-ins/String/prototype/replace/15.5.4.11-1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/cstm-replace-get-err.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/cstm-replace-invocation.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/length.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/name.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/replaceValue-evaluation-order.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T10.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T11.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T12.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T13.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T14.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T17.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T2.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T4.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T5.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T6.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T7.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T8.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A1_T9.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A12.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T10.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T2.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T3.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T4.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T5.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T6.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T7.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T8.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A2_T9.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T2.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T3.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A4_T1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A4_T2.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A4_T3.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A4_T4.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A5_T1.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/S15.5.4.11_A6.js",  # Needs String.prototype.replace
-    "/test/built-ins/String/prototype/replace/this-value-not-obj-coercible.js",  # Needs String.prototype.replace
+    "/test/built-ins/String/prototype/replace/S15.5.4.11_A5_T1.js",  # Needs Regex Decimal Backrefrence
+    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T1.js",  # Needs Regex Character Class Escape
+    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T2.js",  # Needs Regex Character Class Escape
+    "/test/built-ins/String/prototype/replace/S15.5.4.11_A3_T3.js",  # Needs Regex Character Class Escape
     "/test/built-ins/String/prototype/search/cstm-search-get-err.js",  # Needs String.prototype.search
     "/test/built-ins/String/prototype/search/cstm-search-invocation.js",  # Needs String.prototype.search
     "/test/built-ins/String/prototype/search/invoke-builtin-search-searcher-undef.js",  # Needs String.prototype.search

--- a/tests/test_test262.py
+++ b/tests/test_test262.py
@@ -485,7 +485,6 @@ xfail_tests = (
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-55.js",  # Needs Array.prototype.some
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-58.js",  # Needs Array.prototype.filter
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-60.js",  # Needs Array.prototype.reduceRight
-    "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-69.js",  # Needs String.prototype.replace
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-70.js",  # Needs String.prototype.search
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-77.js",  # Needs String.prototype.toUpperCase
     "/test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-79.js",  # Needs String.prototype.toLocaleLowerCase


### PR DESCRIPTION
The `replace()` method returns a new string with some or all matches of a pattern replaced by a replacement. The pattern can be a string or a RegExp, and the replacement can be a string or a function to be called for each match. If pattern is a string, only the first occurrence will be replaced.

The original string is left unchanged.

[Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)